### PR TITLE
fix: Remove working directory and use a lazy shared docker connection

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -29,7 +29,7 @@ jobs:
           tool: cargo-llvm-cov
       - name: Generate code coverage
         run: |
-          cargo +nightly llvm-cov --tests --all-features --lcov --output-path lcov.info
+          cargo +nightly llvm-cov --tests --all-features --lcov --output-path lcov.info -j 2
 
       - name: Coveralls
         uses: coverallsapp/github-action@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,4 +47,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: "Test"
-        run: cargo nextest run
+        run: cargo nextest run -j 2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,8 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
+  RUST_LOG: "debug"
+  RUST_BACKTRACE: 1
 
 jobs:
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ dirs = "6.0"
 
 [dev-dependencies]
 swiftide-agents = "0.17"
-test-log = "0.2"
+test-log = { version = "0.2", features = ["trace"] }
 tempfile = "3.15"

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -1,0 +1,20 @@
+# A lightweight image used for tests
+FROM busybox:latest
+
+# RUN rustup component add clippy rustfmt
+#
+# # Install tool dependencies for app and git/ssh for the workspace
+# RUN apt-get update && apt-get install -y --no-install-recommends \
+#   ripgrep fd-find git ssh curl  \
+#   protobuf-compiler \
+#   libprotobuf-dev \
+#   pkg-config libssl-dev iputils-ping \
+#   make \
+#   && rm -rf /var/lib/apt/lists/* \
+#   && cp /usr/bin/fdfind /usr/bin/fd
+#
+# RUN cargo install cargo-tarpaulin
+
+COPY . /app
+
+WORKDIR /app

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,90 @@
+use std::{
+    ops::Deref,
+    path::Path,
+    sync::{Arc, OnceLock, Weak},
+};
+
+use dirs::{home_dir, runtime_dir};
+use tokio::sync::Mutex;
+
+use crate::ClientError;
+
+// We use `Weak` in order not to prevent `Drop` of being called.
+// Instead, we re-create the client if it was dropped and asked one more time.
+// This way we provide on `Drop` guarantees and avoid unnecessary instantiation at the same time.
+// <3 testcontainers for figuring this out
+static DOCKER_CLIENT: OnceLock<Mutex<Weak<Client>>> = OnceLock::new();
+const DEFAULT_DOCKER_SOCKET: &str = "/var/run/docker.sock";
+
+#[derive(Debug)]
+pub struct Client {
+    bollar_client: bollard::Docker,
+    pub socket_path: String,
+}
+
+impl Client {
+    fn new() -> Result<Self, ClientError> {
+        let socket_path = get_socket_path();
+        let bollar_client =
+            bollard::Docker::connect_with_socket(&socket_path, 120, bollard::API_DEFAULT_VERSION)
+                .map_err(ClientError::Init)?;
+
+        Ok(Self {
+            bollar_client,
+            socket_path,
+        })
+    }
+    /// Returns a client instance, reusing already created or initializing a new one.
+    pub(crate) async fn lazy_client() -> Result<Arc<Client>, ClientError> {
+        let mut guard = DOCKER_CLIENT
+            .get_or_init(|| Mutex::new(Weak::new()))
+            .lock()
+            .await;
+        let maybe_client = guard.upgrade();
+
+        if let Some(client) = maybe_client {
+            Ok(client)
+        } else {
+            let client = Arc::new(Client::new()?);
+            *guard = Arc::downgrade(&client);
+
+            Ok(client)
+        }
+    }
+}
+
+impl Deref for Client {
+    type Target = bollard::Docker;
+
+    fn deref(&self) -> &Self::Target {
+        &self.bollar_client
+    }
+}
+
+/// Lovingly copied from testcontainers-rs
+/// Reliably gets the path to the docker socket
+fn get_socket_path() -> String {
+    validate_path("/var/run/docker.sock".into())
+        .or_else(|| {
+            runtime_dir()
+                .and_then(|dir| validate_path(format!("{}/.docker/run/docker.sock", dir.display())))
+        })
+        .or_else(|| {
+            home_dir()
+                .and_then(|dir| validate_path(format!("{}/.docker/run/docker.sock", dir.display())))
+        })
+        .or_else(|| {
+            home_dir().and_then(|dir| {
+                validate_path(format!("{}/.docker/desktop/docker.sock", dir.display()))
+            })
+        })
+        .unwrap_or(DEFAULT_DOCKER_SOCKET.into())
+}
+
+fn validate_path(path: String) -> Option<String> {
+    if Path::new(&path).exists() {
+        Some(path)
+    } else {
+        None
+    }
+}

--- a/src/context_builder.rs
+++ b/src/context_builder.rs
@@ -42,10 +42,19 @@ impl ContextBuilder {
 
     fn is_ignored(&self, path: impl AsRef<Path>) -> bool {
         let Ok(relative_path) = path.as_ref().strip_prefix(&self.context_path) else {
+            tracing::debug!(
+                "not ignoring {path} as it seems to be not prefixed by {prefix}",
+                path = path.as_ref().display(),
+                prefix = self.context_path.to_string_lossy()
+            );
             return false;
         };
 
         if relative_path.starts_with(".git") {
+            tracing::debug!(
+                "not ignoring {path} as it seems to be a git file",
+                path = path.as_ref().display()
+            );
             return false;
         }
 

--- a/src/context_builder.rs
+++ b/src/context_builder.rs
@@ -104,7 +104,7 @@ mod tests {
     use std::io::Write;
     use tempfile::tempdir;
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_is_ignored() {
         let dir = tempdir().unwrap();
         let context_path = dir.path().to_path_buf();
@@ -135,7 +135,7 @@ mod tests {
         assert!(!context_builder.is_ignored(&txt_file));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_adds_git_even_if_in_ignore() {
         let dir = tempdir().unwrap();
         let context_path = dir.path().to_path_buf();
@@ -149,7 +149,7 @@ mod tests {
         assert!(!context_builder.is_ignored(".git"));
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_works_without_gitignore() {
         let dir = tempdir().unwrap();
         let context_path = dir.path().to_path_buf();

--- a/src/docker_tool_executor.rs
+++ b/src/docker_tool_executor.rs
@@ -8,8 +8,6 @@ use crate::{DockerExecutorError, RunningDockerExecutor};
 pub struct DockerExecutor {
     context_path: PathBuf,
     image_name: String,
-    #[allow(dead_code)]
-    working_dir: PathBuf,
     dockerfile: PathBuf,
     container_uuid: Uuid,
 }
@@ -20,7 +18,6 @@ impl Default for DockerExecutor {
             container_uuid: Uuid::new_v4(),
             context_path: ".".into(),
             image_name: "docker-executor".into(),
-            working_dir: ".".into(),
             dockerfile: "Dockerfile".into(),
         }
     }
@@ -51,14 +48,6 @@ impl DockerExecutor {
     /// Overwrite the dockerfile to use (default "Dockerfile")
     pub fn with_dockerfile(&mut self, path: impl Into<PathBuf>) -> &mut Self {
         self.dockerfile = path.into();
-        self
-    }
-
-    #[allow(dead_code)]
-    /// Override the working directory (default ".")
-    pub fn with_working_dir(&mut self, path: impl Into<PathBuf>) -> &mut Self {
-        self.working_dir = path.into();
-
         self
     }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,9 @@ pub enum DockerExecutorError {
 
     #[error("container state missing for {0}")]
     ContainerStateMissing(String),
+
+    #[error("error initializing client")]
+    Init(#[from] ClientError),
 }
 
 #[derive(Error, Debug)]
@@ -27,6 +30,12 @@ pub enum ContextError {
 
     #[error("failed to convert to relative path")]
     RelativePath(#[from] StripPrefixError),
+}
+
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error("failed to initialize client")]
+    Init(bollard::errors::Error),
 }
 
 impl From<Infallible> for DockerExecutorError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 //! # Ok(())
 //! # }
 //! ```
+mod client;
 mod context_builder;
 mod docker_tool_executor;
 mod errors;

--- a/src/running_docker_executor.rs
+++ b/src/running_docker_executor.rs
@@ -7,8 +7,6 @@ use swiftide_core::{prelude::StreamExt as _, Command, CommandError, CommandOutpu
 use tracing::info;
 use uuid::Uuid;
 
-const DEFAULT_DOCKER_SOCKET: &str = "/var/run/docker.sock";
-
 use bollard::{
     container::{
         Config, CreateContainerOptions, LogOutput, RemoveContainerOptions, StartContainerOptions,
@@ -19,12 +17,12 @@ use bollard::{
     Docker, API_DEFAULT_VERSION,
 };
 
-use crate::{ContextBuilder, DockerExecutorError};
+use crate::{client::Client, ContextBuilder, DockerExecutorError};
 
 #[derive(Clone, Debug)]
 pub struct RunningDockerExecutor {
     pub container_id: String,
-    pub(crate) docker: Docker,
+    pub(crate) docker: Arc<Client>,
 }
 
 impl From<RunningDockerExecutor> for Arc<dyn ToolExecutor> {
@@ -54,8 +52,7 @@ impl RunningDockerExecutor {
         dockerfile: &Path,
         image_name: &str,
     ) -> Result<RunningDockerExecutor, DockerExecutorError> {
-        let socket_path = get_socket_path();
-        let docker = Docker::connect_with_socket(&socket_path, 120, API_DEFAULT_VERSION)?;
+        let docker = Client::lazy_client().await?;
 
         tracing::warn!(
             "Creating archive for context from {}",
@@ -90,6 +87,7 @@ impl RunningDockerExecutor {
             }
         }
 
+        let socket_path = &docker.socket_path;
         let config = Config {
             image: Some(image_name.as_str()),
             tty: Some(true),
@@ -274,33 +272,5 @@ impl Drop for RunningDockerExecutor {
         if let Err(e) = result {
             tracing::warn!(error = %e, "Error stopping container, might not be stopped");
         }
-    }
-}
-
-/// Lovingly copied from testcontainers-rs
-/// Reliably gets the path to the docker socket
-fn get_socket_path() -> String {
-    validate_path("/var/run/docker.sock".into())
-        .or_else(|| {
-            runtime_dir()
-                .and_then(|dir| validate_path(format!("{}/.docker/run/docker.sock", dir.display())))
-        })
-        .or_else(|| {
-            home_dir()
-                .and_then(|dir| validate_path(format!("{}/.docker/run/docker.sock", dir.display())))
-        })
-        .or_else(|| {
-            home_dir().and_then(|dir| {
-                validate_path(format!("{}/.docker/desktop/docker.sock", dir.display()))
-            })
-        })
-        .unwrap_or(DEFAULT_DOCKER_SOCKET.into())
-}
-
-fn validate_path(path: String) -> Option<String> {
-    if Path::new(&path).exists() {
-        Some(path)
-    } else {
-        None
     }
 }

--- a/src/running_docker_executor.rs
+++ b/src/running_docker_executor.rs
@@ -1,6 +1,5 @@
 use anyhow::Context as _;
 use async_trait::async_trait;
-use dirs::{home_dir, runtime_dir};
 use std::{path::Path, sync::Arc};
 pub use swiftide_core::ToolExecutor;
 use swiftide_core::{prelude::StreamExt as _, Command, CommandError, CommandOutput};
@@ -14,7 +13,6 @@ use bollard::{
     exec::{CreateExecOptions, StartExecResults},
     image::BuildImageOptions,
     secret::{ContainerState, ContainerStateStatusEnum},
-    Docker, API_DEFAULT_VERSION,
 };
 
 use crate::{client::Client, ContextBuilder, DockerExecutorError};

--- a/src/running_docker_executor.rs
+++ b/src/running_docker_executor.rs
@@ -230,9 +230,13 @@ impl RunningDockerExecutor {
 
         // If the directory or file does not exist, create it
         if let Err(CommandError::NonZeroExit(write_file)) = &write_file_result {
-            if ["No such file or directory", "Directory nonexistent"]
-                .iter()
-                .any(|&s| write_file.output.contains(s))
+            if [
+                "no such file or directory",
+                "directory nonexistent",
+                "nonexistent directory",
+            ]
+            .iter()
+            .any(|&s| write_file.output.to_lowercase().contains(s))
             {
                 let path = path.parent().context("No parent directory")?;
                 let mkdircmd = format!("mkdir -p {}", path.display());

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -28,14 +28,11 @@ async fn test_context_present() {
     let executor = DockerExecutor::default()
         .with_context_path(".")
         .with_image_name("tests")
-        .with_working_dir("/app")
         .to_owned()
         .start()
         .await
         .unwrap();
 
-    // Verify that the working directory is set correctly
-    // TODO: Annoying this needs to be updated when files change in the root. Think of something better.
     let ls = executor
         .exec_cmd(&Command::Shell("ls -a".to_string()))
         .await
@@ -105,7 +102,6 @@ async fn test_write_and_read_file_with_quotes() {
     let executor = DockerExecutor::default()
         .with_context_path(".")
         .with_image_name("test-files")
-        .with_working_dir("/app")
         .to_owned()
         .start()
         .await
@@ -143,7 +139,6 @@ async fn test_write_and_read_file_markdown() {
     let executor = DockerExecutor::default()
         .with_context_path(".")
         .with_image_name("test-files-md")
-        .with_working_dir("/app")
         .to_owned()
         .start()
         .await
@@ -167,7 +162,6 @@ async fn test_assert_container_stopped_on_drop() {
     let executor = DockerExecutor::default()
         .with_context_path(".")
         .with_image_name("test-drop")
-        .with_working_dir("/app")
         .to_owned()
         .start()
         .await
@@ -222,7 +216,6 @@ async fn test_create_file_subdirectory_that_does_not_exist() {
     let executor = DockerExecutor::default()
         .with_context_path(".")
         .with_image_name("test-files-missing-dir")
-        .with_working_dir("/app")
         .to_owned()
         .start()
         .await

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,9 +5,13 @@ use swiftide_core::{Command, ToolExecutor as _};
 
 use crate::{DockerExecutor, DockerExecutorError};
 
+// A much smaller busybox image for faster tests
+const TEST_DOCKERFILE: &str = "Dockerfile.tests";
+
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_runs_docker_and_echos() {
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(".")
         .with_image_name("tests")
         .to_owned()
@@ -26,6 +30,7 @@ async fn test_runs_docker_and_echos() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_context_present() {
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(".")
         .with_image_name("tests")
         .to_owned()
@@ -54,7 +59,7 @@ async fn test_overrides_include_git_respects_ignore() {
     std::fs::write(context_path.path().join("ignored_file"), "hello").unwrap();
 
     std::process::Command::new("cp")
-        .arg("Dockerfile")
+        .arg(TEST_DOCKERFILE)
         .arg(context_path.path().join("Dockerfile"))
         .output()
         .unwrap();
@@ -100,6 +105,7 @@ async fn test_write_and_read_file_with_quotes() {
     let path = Path::new("test_file.txt");
 
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(".")
         .with_image_name("test-files")
         .to_owned()
@@ -137,6 +143,7 @@ async fn test_write_and_read_file_markdown() {
     let path = Path::new("test_file.txt");
 
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(".")
         .with_image_name("test-files-md")
         .to_owned()
@@ -160,6 +167,7 @@ async fn test_write_and_read_file_markdown() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_assert_container_stopped_on_drop() {
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(".")
         .with_image_name("test-drop")
         .to_owned()
@@ -214,6 +222,7 @@ async fn test_create_file_subdirectory_that_does_not_exist() {
     let path = Path::new("doesnot/exist/test_file.txt");
 
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(".")
         .with_image_name("test-files-missing-dir")
         .to_owned()
@@ -246,6 +255,7 @@ async fn test_custom_dockerfile() {
         .unwrap();
 
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(context_path.path())
         .with_image_name("test-custom")
         .with_dockerfile("Dockerfile.custom")
@@ -275,6 +285,7 @@ async fn test_nullifies_cmd() {
     std::fs::write(context_path.path().join("Dockerfile"), dockerfile_content).unwrap();
 
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(context_path.path())
         .with_image_name("test-null-cmd")
         .with_dockerfile("Dockerfile")
@@ -304,6 +315,7 @@ async fn test_nullifies_entrypoint() {
     std::fs::write(context_path.path().join("Dockerfile"), dockerfile_content).unwrap();
 
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(context_path.path())
         .with_image_name("test-null-entrypoint")
         .with_dockerfile("Dockerfile")
@@ -322,6 +334,7 @@ async fn test_nullifies_entrypoint() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_container_state() {
     let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(".")
         .with_image_name("test-state")
         .to_owned()
@@ -348,6 +361,7 @@ async fn test_invalid_dockerfile() {
     std::fs::write(context_path.path().join("Dockerfile"), dockerfile_content).unwrap();
 
     let err = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
         .with_context_path(context_path.path())
         .with_image_name("test-invalid")
         .with_dockerfile("Dockerfile")


### PR DESCRIPTION
Removes the working dir as it's not used and is confusing with the context path. Additionally use a shared docker connection between executors. 
