### PR TITLE
Fix: Do not override workdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /swiftide-docker-executor/src/resources
+kwaak.local.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-err"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f89bda4c2a21204059a977ed3bfe746677dfd137b83c339e702b0ac91d482aa"
+dependencies = [
+ "autocfg",
+ "tokio",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,6 +1967,7 @@ dependencies = [
  "bollard",
  "dirs",
  "flate2",
+ "fs-err",
  "http-body-util",
  "ignore",
  "indoc",

--- a/swiftide-docker-executor/Cargo.toml
+++ b/swiftide-docker-executor/Cargo.toml
@@ -30,6 +30,7 @@ tempfile = "3.15"
 http-body-util = "0.1.2"
 flate2 = "1.0"
 tokio.workspace = true
+fs-err = { version = "3.1.0", features = ["tokio"] }
 
 tonic.workspace = true
 prost.workspace = true

--- a/swiftide-docker-executor/src/context_builder.rs
+++ b/swiftide-docker-executor/src/context_builder.rs
@@ -133,7 +133,7 @@ impl ContextBuilder {
                 // Indicate it's a symlink
                 header.set_entry_type(EntryType::Symlink);
                 // The tar specification requires setting the link name for a symlink
-                if let Err(error) = header.set_link_name(link_target) {
+                if let Err(error) = header.set_link_name(&link_target) {
                     tracing::warn!(?error, "Failed to set link name on {link_target:#?}");
                     continue;
                 }

--- a/swiftide-docker-executor/src/errors.rs
+++ b/swiftide-docker-executor/src/errors.rs
@@ -37,16 +37,16 @@ pub enum DockerExecutorError {
 
 #[derive(Error, Debug)]
 pub enum ContextError {
-    #[error("error while trying to ignore files")]
+    #[error("error while trying to ignore files: {0}")]
     FailedIgnore(#[from] ignore::Error),
 
-    #[error("failed while walking files in context")]
+    #[error("failed while walking files in context: {0}")]
     Walk(#[from] walkdir::Error),
 
-    #[error("error reading file")]
+    #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    #[error("failed to convert to relative path")]
+    #[error("failed to convert to relative path{0}")]
     RelativePath(#[from] StripPrefixError),
 }
 

--- a/swiftide-docker-executor/src/tests.rs
+++ b/swiftide-docker-executor/src/tests.rs
@@ -455,7 +455,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/* \
   && cp /usr/bin/fdfind /usr/bin/fd
 
-RUN cargo install cargo-llvm-cov cargo-nextest
 
 COPY . /app
 

--- a/swiftide-docker-service/src/grpc_service.rs
+++ b/swiftide-docker-service/src/grpc_service.rs
@@ -26,7 +26,6 @@ impl ShellExecutor for MyShellExecutor {
         let output = Command::new("sh")
             .arg("-c")
             .arg(command)
-            .current_dir("/app")
             .output()
             .await
             .map_err(|e| Status::internal(format!("Failed to run command: {:?}", e)))?;


### PR DESCRIPTION
- **chore: Ignore local kwaak file**
- **chore: Ensure context errors are either transparent or display the message properly**
- **chore: Improve fs errors and ignore symlinks with errors**
- **Remove nextest**
- **fix: Use workdir from image**
