### PR TITLE
feat: Stream command output to container output with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,6 +1996,8 @@ dependencies = [
  "tokio",
  "tonic",
  "tonic-build",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2380,6 +2382,7 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ resolver = "2"
 tonic = { version = "0.12" }
 prost = "0.13"
 tonic-build = "0.12"
+tracing = "0.1"
 tokio = { version = "1", features = ["full"] }
 
 [workspace.package]

--- a/Justfile
+++ b/Justfile
@@ -2,3 +2,7 @@ version :=  `cargo metadata --format-version=1 --no-deps | jq '.packages[0].vers
 
 docker-build-service:
   docker build  -t bosunai/swiftide-docker-service:{{version}} -f swiftide-docker-service/Dockerfile .
+
+docker-run-service: docker-build-service
+  docker run -p 50051:50051 bosunai/swiftide-docker-service:{{version}} swiftide-docker-service
+

--- a/swiftide-docker-executor/Cargo.toml
+++ b/swiftide-docker-executor/Cargo.toml
@@ -22,7 +22,7 @@ ignore = "0.4"
 walkdir = "2.5"
 tokio-tar = "0.3"
 uuid = { version = "1.12", features = ["v4"] }
-tracing = "0.1"
+tracing.workspace = true
 indoc = "2.0"
 anyhow = "1.0"
 dirs = "6.0"

--- a/swiftide-docker-executor/src/running_docker_executor.rs
+++ b/swiftide-docker-executor/src/running_docker_executor.rs
@@ -7,10 +7,7 @@ use bollard::{
 use shell::shell_executor_client::ShellExecutorClient;
 use std::{path::Path, sync::Arc};
 pub use swiftide_core::ToolExecutor;
-use swiftide_core::{
-    prelude::{StreamExt as _, TryStreamExt},
-    Command, CommandError, CommandOutput,
-};
+use swiftide_core::{prelude::StreamExt as _, Command, CommandError, CommandOutput};
 use uuid::Uuid;
 
 use crate::{

--- a/swiftide-docker-service/Cargo.toml
+++ b/swiftide-docker-service/Cargo.toml
@@ -16,6 +16,8 @@ categories.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tonic.workspace = true
 prost.workspace = true
+tracing.workspace = true
+tracing-subscriber = { version = "0.3" }
 
 [build-dependencies]
 tonic-build = { workspace = true }

--- a/swiftide-docker-service/src/grpc_service.rs
+++ b/swiftide-docker-service/src/grpc_service.rs
@@ -1,4 +1,8 @@
+use std::process::Stdio;
+
+use tokio::io::AsyncBufReadExt as _;
 use tokio::process::Command;
+use tokio::task::JoinSet;
 use tonic::{Request, Response, Status};
 
 // The module `shell` is created by Tonic automatically because your
@@ -16,27 +20,88 @@ pub struct MyShellExecutor;
 
 #[tonic::async_trait]
 impl ShellExecutor for MyShellExecutor {
+    #[tracing::instrument(skip_all)]
     async fn exec_shell(
         &self,
         request: Request<ShellRequest>,
     ) -> Result<Response<ShellResponse>, Status> {
         let ShellRequest { command } = request.into_inner();
 
+        tracing::info!(command, "Received command");
+
         // Run the command in a shell
-        let output = Command::new("sh")
+        let mut child = Command::new("sh")
             .arg("-c")
-            .arg(command)
+            .arg(&command)
             .current_dir("/app")
-            .output()
-            .await
-            .map_err(|e| Status::internal(format!("Failed to run command: {:?}", e)))?;
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| {
+                tracing::error!(error = ?e, "Failed to start command");
+                Status::internal(format!("Failed to start command: {:?}", e))
+            })?;
+
+        // NOTE: Feels way overcomplicated just because we want both stderr and stdout
+        let mut joinset = JoinSet::new();
+
+        if let Some(stdout) = child.stdout.take() {
+            joinset.spawn(async move {
+                let mut lines = tokio::io::BufReader::new(stdout).lines();
+                let mut out = Vec::new();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    tracing::info!("stdout: {line}");
+                    out.push(line);
+                }
+                out
+            });
+        } else {
+            tracing::warn!("Command has no stdout");
+        }
+
+        if let Some(stderr) = child.stderr.take() {
+            joinset.spawn(async move {
+                let mut lines = tokio::io::BufReader::new(stderr).lines();
+                let mut out = Vec::new();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    tracing::info!("stderr: {line}");
+                    out.push(line);
+                }
+                out
+            });
+        } else {
+            tracing::warn!("Command has no stderr");
+        }
+
+        let outputs = joinset.join_all().await;
+        let &[stdout, stderr] = outputs
+            .iter()
+            .map(Vec::as_slice)
+            .collect::<Vec<_>>()
+            .as_slice()
+        else {
+            // This should never happen
+            tracing::error!("Failed to get outputs");
+            return Err(Status::internal("Failed to join stdout and stderr"));
+        };
+
+        // outputs stdout and stderr should be empty
+        let output = child.wait_with_output().await.map_err(|e| {
+            tracing::error!(error = ?e, "Failed to wait for command");
+            Status::internal(format!("Failed to wait for command: {:?}", e))
+        })?;
+
+        debug_assert!(stdout.is_empty());
+        debug_assert!(stderr.is_empty());
 
         // Prepare response
         let response = ShellResponse {
             exit_code: output.status.code().unwrap_or(-1),
-            stdout: String::from_utf8_lossy(&output.stdout).to_string(),
-            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+            stdout: stdout.join("\n"),
+            stderr: stderr.join("\n"),
         };
+
+        tracing::info!(command, exit_code = response.exit_code, "Command executed");
 
         Ok(Response::new(response))
     }

--- a/swiftide-docker-service/src/main.rs
+++ b/swiftide-docker-service/src/main.rs
@@ -5,10 +5,15 @@ mod grpc_service;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt()
+        .compact()
+        .with_ansi(false)
+        .with_target(false)
+        .init();
     let addr = "0.0.0.0:50051".parse()?;
     let shell_executor = MyShellExecutor;
 
-    println!("ShellExecutor gRPC server listening on {}", addr);
+    tracing::warn!("ShellExecutor gRPC server listening on {}", addr);
 
     Server::builder()
         .add_service(ShellExecutorServer::new(shell_executor))


### PR DESCRIPTION
Streams log output to stdout in the container while a command is running, instead of at the end. Wraps it with tracing because that is how we roll.

Should make it a lot easier to debug long running commands.