### PR TITLE
Make swiftide-docker-service built on alpine so it has statically linked glibc

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 version :=  `cargo metadata --format-version=1 --no-deps | jq -r '.packages[0].version'`
 
 docker-build-service:
-  docker build -t bosunai/swiftide-docker-service:{{version}} -t bosunai/swiftide-docker-service:latest -f swiftide-docker-service/Dockerfile .
+  docker buildx build --platform linux/amd64,linux/arm64 -t bosunai/swiftide-docker-service:{{version}} -t bosunai/swiftide-docker-service:latest -f swiftide-docker-service/Dockerfile .
 
 docker-run-service: docker-build-service
   docker run -p 50051:50051 bosunai/swiftide-docker-service:{{version}} swiftide-docker-service

--- a/swiftide-docker-service/Dockerfile
+++ b/swiftide-docker-service/Dockerfile
@@ -1,19 +1,26 @@
 # This dockerfile is used to build the swiftide-docker-service image
-FROM rust:1.89-slim as builder
+# Using Alpine + musl for fully static binaries (no glibc dependency)
+FROM rust:1.89-alpine as builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  protobuf-compiler \
-  libprotobuf-dev \
-  pkg-config libssl-dev iputils-ping \
+RUN apk add --no-cache \
+  musl-dev \
+  protobuf-dev \
+  protoc \
+  pkgconfig \
+  openssl-dev \
+  openssl-libs-static \
   make \
-  # Avoid flaky symlinked binaries from alpine
-  fd-find \
-  ripgrep \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+  perl
+
+# Install static versions of fd and ripgrep
+RUN apk add --no-cache fd ripgrep
 
 COPY . /app
 WORKDIR /app
+
+ENV OPENSSL_STATIC=1
+ENV OPENSSL_LIB_DIR=/usr/lib
+ENV OPENSSL_INCLUDE_DIR=/usr/include
 
 RUN \
   --mount=type=cache,target=/app/target/ \
@@ -25,12 +32,10 @@ RUN \
 FROM alpine as runtime
 
 COPY --from=builder /usr/bin/swiftide-docker-service /usr/bin/swiftide-docker-service
-COPY --from=builder /usr/bin/fdfind /usr/bin/fd
+COPY --from=builder /usr/bin/fd /usr/bin/fd
 COPY --from=builder /usr/bin/rg /usr/bin/rg
 
 WORKDIR /app
-
-RUN apk add gcompat libgcc
 
 EXPOSE 50051
 CMD ["swiftide-docker-service"]


### PR DESCRIPTION
This lets it be copied into docker images that have different versions of glibc, like old versions of Ubuntu