### PR TITLE
feat: add read-only shell executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,7 +2390,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "swiftide-agents"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "swiftide-core"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "swiftide-indexing"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "swiftide-macros"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "swiftide-tasks"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
 dependencies = [
  "async-trait",
  "dyn-clone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,7 +2390,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "swiftide-agents"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "swiftide-core"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "swiftide-indexing"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "swiftide-macros"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "swiftide-tasks"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#cd4428bc62a7f637243cd388cf9357a040cfe721"
 dependencies = [
  "async-trait",
  "dyn-clone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,7 +693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2043,7 +2043,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2390,7 +2390,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "swiftide-agents"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "swiftide-core"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "swiftide-indexing"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "swiftide-macros"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "swiftide-tasks"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#46506dd7127648cd1143572b54bf68235c651303"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
 dependencies = [
  "async-trait",
  "dyn-clone",
@@ -2590,7 +2590,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3228,7 +3228,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2390,7 +2390,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "swiftide-agents"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#74bebd78ecfe3feee9867fa03d6f12fcb925fbf7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "swiftide-core"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#74bebd78ecfe3feee9867fa03d6f12fcb925fbf7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "swiftide-indexing"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#74bebd78ecfe3feee9867fa03d6f12fcb925fbf7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2525,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "swiftide-macros"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#74bebd78ecfe3feee9867fa03d6f12fcb925fbf7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "swiftide-tasks"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#a39ac766f787d313d1a55404f15f0c1371090657"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#74bebd78ecfe3feee9867fa03d6f12fcb925fbf7"
 dependencies = [
  "async-trait",
  "dyn-clone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "astral-tokio-tar"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,6 +640,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1344,17 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "landlock"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635839550ae8b90d9fd2571460a6645dc0aec070225956ca7a2831ed31d2795d"
+dependencies = [
+ "enumflags2",
+ "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -2359,7 +2390,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "swiftide-agents"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=master#9c9746cda928f589f2d594e29e1e5a5d79cb8a6b"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2376,6 +2407,7 @@ dependencies = [
  "strum_macros 0.28.0",
  "swiftide-core",
  "swiftide-indexing",
+ "swiftide-tasks",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -2386,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "swiftide-core"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=master#9c9746cda928f589f2d594e29e1e5a5d79cb8a6b"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2450,6 +2482,7 @@ version = "0.13.7"
 dependencies = [
  "futures-util",
  "indoc",
+ "landlock",
  "libc",
  "prost",
  "swiftide-core",
@@ -2466,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "swiftide-indexing"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=master#9c9746cda928f589f2d594e29e1e5a5d79cb8a6b"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2492,7 +2525,7 @@ dependencies = [
 [[package]]
 name = "swiftide-macros"
 version = "0.32.1"
-source = "git+https://github.com/bosun-ai/swiftide?branch=master#9c9746cda928f589f2d594e29e1e5a5d79cb8a6b"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2504,6 +2537,19 @@ dependencies = [
  "serde",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "swiftide-tasks"
+version = "0.32.1"
+source = "git+https://github.com/bosun-ai/swiftide?branch=feat%2Fread-only-shell-command#0b74e195f02f8f32c3e8507caec0fbeaa09cac51"
+dependencies = [
+ "async-trait",
+ "dyn-clone",
+ "futures-util",
+ "swiftide-core",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,6 @@ version = "0.13.7"
 categories = ["asynchronous"]
 
 [patch.crates-io]
-swiftide-core = { git = "https://github.com/bosun-ai/swiftide", package = "swiftide-core", branch = "master" }
-swiftide-indexing = { git = "https://github.com/bosun-ai/swiftide", package = "swiftide-indexing", branch = "master" }
-swiftide-agents = { git = "https://github.com/bosun-ai/swiftide", package = "swiftide-agents", branch = "master" }
+swiftide-core = { git = "https://github.com/bosun-ai/swiftide", package = "swiftide-core", branch = "feat/read-only-shell-command" }
+swiftide-indexing = { git = "https://github.com/bosun-ai/swiftide", package = "swiftide-indexing", branch = "feat/read-only-shell-command" }
+swiftide-agents = { git = "https://github.com/bosun-ai/swiftide", package = "swiftide-agents", branch = "feat/read-only-shell-command" }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ let tmp_pwd = executor
 
 The same resolution logic applies to `Command::read_file` and `Command::write_file`, so relative file paths are always interpreted relative to the effective working directory for that command.
 
+## Read-only shell commands
+
+`Command::read_only_shell` uses a separate gRPC method from unrestricted shell execution. This is intentional: older services that do not implement the method return `UNIMPLEMENTED` instead of accidentally running the command through full shell access.
+
+On Linux, the service runs read-only shell commands under a Landlock ruleset. The ruleset handles write-like filesystem rights and grants them only to a per-command temporary `HOME` / `TMPDIR`. Reads and command execution are left alone, so agents can still use normal shell tools to inspect a checkout, while attempts to mutate the executor workspace fail. The command also runs with a sanitized environment and `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
+
+Executors that cannot enforce these semantics return an error. They must not fall back to `Command::shell`.
+
 ## Timeouts
 
 Long-running commands can be bounded either globally or per invocation. Set a default timeout that applies to every command with `.with_default_timeout(Duration)`:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The same resolution logic applies to `Command::read_file` and `Command::write_fi
 
 `Command::read_only_shell` uses a separate gRPC method from unrestricted shell execution. This is intentional: older services that do not implement the method return `UNIMPLEMENTED` instead of accidentally running the command through full shell access.
 
-On Linux, the service runs read-only shell commands under a Landlock ruleset plus a small seccomp filter. Landlock handles write-like filesystem rights and grants them only to a per-command temporary `TMPDIR`; seccomp denies metadata mutation such as chmod, chown, and timestamp changes. Reads and command execution are left alone, so agents can still use normal shell tools to inspect a checkout, while attempts to mutate the executor workspace fail. The command preserves the configured executor environment, including `HOME`, and defaults `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
+On Linux, the service runs read-only shell commands under a Landlock ruleset plus a small seccomp filter. Landlock handles write-like filesystem rights and grants them only to a per-command temporary `TMPDIR`; seccomp denies metadata mutation such as chmod, chown, and timestamp changes. Reads and command execution are left alone inside the executor container, while attempts to mutate the executor workspace fail. The command preserves the configured executor environment, including `HOME`, and defaults `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
 
 The high-level Docker executor tests exercise this through the normal gRPC path:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The same resolution logic applies to `Command::read_file` and `Command::write_fi
 
 `Command::read_only_shell` uses a separate gRPC method from unrestricted shell execution. This is intentional: older services that do not implement the method return `UNIMPLEMENTED` instead of accidentally running the command through full shell access.
 
-On Linux, the service runs read-only shell commands under a Landlock ruleset plus a small seccomp filter. Landlock handles write-like filesystem rights and grants them only to a per-command temporary `TMPDIR`; seccomp denies metadata mutation such as chmod, chown, and timestamp changes. Reads and command execution are left alone inside the executor container, while attempts to mutate the executor workspace fail. The command preserves the configured executor environment, including `HOME`, and defaults `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
+On Linux, the service runs read-only shell commands under a Landlock ruleset plus a small seccomp filter. Landlock denies write-like filesystem rights; seccomp denies metadata mutation such as chmod, chown, and timestamp changes. Reads and command execution are left alone inside the executor container, while attempts to write fail. The command preserves the configured executor environment, including `HOME`, and defaults `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
 
 The high-level Docker executor tests exercise this through the normal gRPC path:
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ The same resolution logic applies to `Command::read_file` and `Command::write_fi
 
 `Command::read_only_shell` uses a separate gRPC method from unrestricted shell execution. This is intentional: older services that do not implement the method return `UNIMPLEMENTED` instead of accidentally running the command through full shell access.
 
-On Linux, the service runs read-only shell commands under a Landlock ruleset. The ruleset handles write-like filesystem rights and grants them only to a per-command temporary `HOME` / `TMPDIR`. Reads and command execution are left alone, so agents can still use normal shell tools to inspect a checkout, while attempts to mutate the executor workspace fail. The command also runs with a sanitized environment and `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
+On Linux, the service runs read-only shell commands under a Landlock ruleset. The ruleset handles write-like filesystem rights and grants them only to a per-command temporary `TMPDIR`. Reads and command execution are left alone, so agents can still use normal shell tools to inspect a checkout, while attempts to mutate the executor workspace fail. The command preserves the configured executor environment, including `HOME`, and defaults `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
+
+The high-level Docker executor tests exercise this through the normal gRPC path:
+
+```sh
+cargo test -p swiftide-docker-executor test_read_only_shell --locked -- --nocapture
+```
 
 Executors that cannot enforce these semantics return an error. They must not fall back to `Command::shell`.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The same resolution logic applies to `Command::read_file` and `Command::write_fi
 
 `Command::read_only_shell` uses a separate gRPC method from unrestricted shell execution. This is intentional: older services that do not implement the method return `UNIMPLEMENTED` instead of accidentally running the command through full shell access.
 
-On Linux, the service runs read-only shell commands under a Landlock ruleset. The ruleset handles write-like filesystem rights and grants them only to a per-command temporary `TMPDIR`. Reads and command execution are left alone, so agents can still use normal shell tools to inspect a checkout, while attempts to mutate the executor workspace fail. The command preserves the configured executor environment, including `HOME`, and defaults `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
+On Linux, the service runs read-only shell commands under a Landlock ruleset plus a small seccomp filter. Landlock handles write-like filesystem rights and grants them only to a per-command temporary `TMPDIR`; seccomp denies metadata mutation such as chmod, chown, and timestamp changes. Reads and command execution are left alone, so agents can still use normal shell tools to inspect a checkout, while attempts to mutate the executor workspace fail. The command preserves the configured executor environment, including `HOME`, and defaults `GIT_OPTIONAL_LOCKS=0` so common read-only git commands avoid optional lock writes.
 
 The high-level Docker executor tests exercise this through the normal gRPC path:
 

--- a/swiftide-docker-executor/proto/shell.proto
+++ b/swiftide-docker-executor/proto/shell.proto
@@ -35,6 +35,15 @@ message ReadOnlyShellRequest {
 
   // Optional working directory for the command execution.
   optional string cwd = 3;
+
+  // Clears inherited environment variables before applying envs.
+  bool env_clear = 4;
+
+  // Environment variable names to remove before applying envs.
+  repeated string env_remove = 5;
+
+  // Environment variables to set for the read-only command.
+  map<string, string> envs = 6;
 }
 
 // The response message containing exit code, stdout, and stderr.

--- a/swiftide-docker-executor/proto/shell.proto
+++ b/swiftide-docker-executor/proto/shell.proto
@@ -6,6 +6,9 @@ package shell;
 service ShellExecutor {
   // Runs a shell command and returns exit code, stdout, and stderr.
   rpc ExecShell (ShellRequest) returns (ShellResponse) {}
+
+  // Runs a shell command with read-only access to the workspace.
+  rpc ExecReadOnlyShell (ReadOnlyShellRequest) returns (ShellResponse) {}
 }
 
 // The request message containing the command to run.
@@ -21,6 +24,17 @@ message ShellRequest {
 
   // Optional working directory for the command execution.
   optional string cwd = 7;
+}
+
+// The request message containing the read-only command to run.
+message ReadOnlyShellRequest {
+  string command = 1;
+
+  // Optional timeout in milliseconds for the command execution.
+  optional uint64 timeout_ms = 2;
+
+  // Optional working directory for the command execution.
+  optional string cwd = 3;
 }
 
 // The response message containing exit code, stdout, and stderr.

--- a/swiftide-docker-executor/src/running_docker_executor.rs
+++ b/swiftide-docker-executor/src/running_docker_executor.rs
@@ -64,11 +64,16 @@ impl ToolExecutor for RunningDockerExecutor {
 
         match cmd {
             Command::Shell { command, .. } => self.exec_shell(command, &workdir, timeout).await,
+            Command::ReadOnlyShell { command, .. } => {
+                self.exec_read_only_shell(command, &workdir, timeout).await
+            }
             Command::ReadFile { path, .. } => self.exec_read_file(&workdir, path, timeout).await,
             Command::WriteFile { path, content, .. } => {
                 self.exec_write_file(&workdir, path, content, timeout).await
             }
-            _ => unimplemented!(),
+            _ => Err(CommandError::ExecutorError(anyhow::anyhow!(
+                "unsupported command for Docker executor: {cmd:?}"
+            ))),
         }
     }
 
@@ -392,6 +397,66 @@ impl RunningDockerExecutor {
         let stdout = stdout.trim().to_string();
         let stderr = stderr.trim().to_string();
         let output = CommandOutput::from_parts(stdout, stderr);
+
+        if exit_code == 0 {
+            Ok(output)
+        } else {
+            Err(CommandError::NonZeroExit(output))
+        }
+    }
+
+    async fn exec_read_only_shell(
+        &self,
+        cmd: &str,
+        workdir: &Path,
+        timeout: Option<Duration>,
+    ) -> Result<CommandOutput, CommandError> {
+        let mut client = ShellExecutorClient::connect(format!(
+            "http://{}:{}",
+            self.container_ip, self.container_port
+        ))
+        .await
+        .map_err(anyhow::Error::from)?;
+
+        let timeout_ms = timeout.map(duration_to_millis);
+        tracing::debug!(?timeout_ms, "sending read-only shell request with timeout");
+
+        let request = tonic::Request::new(codegen::ReadOnlyShellRequest {
+            command: cmd.to_string(),
+            timeout_ms,
+            cwd: Some(workdir.display().to_string()),
+        });
+
+        let response = match client.exec_read_only_shell(request).await {
+            Ok(resp) => resp.into_inner(),
+            Err(status) => {
+                if status.code() == tonic::Code::DeadlineExceeded
+                    && let Some(limit) = timeout
+                {
+                    let message = status.message().to_string();
+                    let output = if message.is_empty() {
+                        CommandOutput::empty()
+                    } else {
+                        CommandOutput::new(message)
+                    };
+
+                    return Err(CommandError::TimedOut {
+                        timeout: limit,
+                        output,
+                    });
+                }
+
+                return Err(CommandError::ExecutorError(status.into()));
+            }
+        };
+
+        let codegen::ShellResponse {
+            stdout,
+            stderr,
+            exit_code,
+        } = response;
+
+        let output = CommandOutput::from_parts(stdout.trim(), stderr.trim());
 
         if exit_code == 0 {
             Ok(output)

--- a/swiftide-docker-executor/src/running_docker_executor.rs
+++ b/swiftide-docker-executor/src/running_docker_executor.rs
@@ -425,6 +425,9 @@ impl RunningDockerExecutor {
             command: cmd.to_string(),
             timeout_ms,
             cwd: Some(workdir.display().to_string()),
+            env_clear: self.env_clear,
+            env_remove: self.remove_env.clone(),
+            envs: self.env.clone(),
         });
 
         let response = match client.exec_read_only_shell(request).await {

--- a/swiftide-docker-executor/src/tests.rs
+++ b/swiftide-docker-executor/src/tests.rs
@@ -1009,6 +1009,42 @@ printf 'env=%s\nprofile=%s\nhome=%s' "$READ_ONLY_MARKER" "$PROFILE_MARKER" "$HOM
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_read_only_shell_cleans_up_background_children_after_success() {
+    let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
+        .with_context_path(".")
+        .with_image_name("test-read-only-shell-process-group-cleanup")
+        .to_owned()
+        .start()
+        .await
+        .unwrap();
+
+    let command = Command::read_only_shell(
+        r#"
+            sleep 30 &
+            printf '%s\n' "$!"
+        "#,
+    )
+    .with_timeout(Duration::from_secs(3));
+
+    let output = tokio::time::timeout(Duration::from_secs(8), executor.exec_cmd(&command))
+        .await
+        .expect("read-only command should return promptly")
+        .unwrap();
+    let child_pid = output.stdout.trim();
+    assert!(!child_pid.is_empty(), "expected command to print child pid");
+
+    let inspect = Command::shell(format!(
+        r#"if [ -r /proc/{child_pid}/stat ]; then awk '{{ print $3 }}' /proc/{child_pid}/stat; else echo gone; fi"#
+    ));
+    let child_state = executor.exec_cmd(&inspect).await.unwrap().to_string();
+    assert!(
+        child_state == "gone" || child_state == "Z",
+        "read-only background child should be gone or reaped as a zombie, got state {child_state:?}"
+    );
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_clear_env() {
     let executor = DockerExecutor::default()
         .with_dockerfile(TEST_DOCKERFILE)

--- a/swiftide-docker-executor/src/tests.rs
+++ b/swiftide-docker-executor/src/tests.rs
@@ -919,7 +919,7 @@ async fn test_read_only_shell_reads_workdir_and_blocks_writes() {
 
     executor
         .exec_cmd(&Command::shell(
-            "printf original > readonly.txt; rm -f /tmp/swiftide-readonly-outside",
+            "printf original > readonly.txt; rm -f /tmp/swiftide-readonly-outside /tmp/swiftide-readonly-tmp",
         ))
         .await
         .unwrap();
@@ -933,6 +933,9 @@ async fn test_read_only_shell_reads_workdir_and_blocks_writes() {
                 if echo changed > readonly.txt; then echo allowed; else echo denied; fi
                 printf '\noutside='
                 if echo changed > /tmp/swiftide-readonly-outside; then echo allowed; else echo denied; fi
+                printf '\ntmp='
+                tmp="${TMPDIR:-/tmp}"
+                if echo changed > "$tmp/swiftide-readonly-tmp"; then echo allowed; else echo denied; fi
                 printf '\nchmod='
                 if chmod 600 readonly.txt; then echo allowed; else echo denied; fi
                 printf '\nchown='
@@ -955,6 +958,7 @@ async fn test_read_only_shell_reads_workdir_and_blocks_writes() {
             "read=original",
             "workdir=denied",
             "outside=denied",
+            "tmp=denied",
             "chmod=denied",
             "chown=denied",
             "final=original"
@@ -963,7 +967,7 @@ async fn test_read_only_shell_reads_workdir_and_blocks_writes() {
 
     let verify = executor
         .exec_cmd(&Command::shell(
-            "cat readonly.txt; test ! -e /tmp/swiftide-readonly-outside",
+            "cat readonly.txt; test ! -e /tmp/swiftide-readonly-outside; test ! -e /tmp/swiftide-readonly-tmp",
         ))
         .await
         .unwrap();
@@ -1005,42 +1009,6 @@ printf 'env=%s\nprofile=%s\nhome=%s' "$READ_ONLY_MARKER" "$PROFILE_MARKER" "$HOM
             "profile=from-profile",
             "home=/tmp/swiftide-readonly-home"
         ]
-    );
-}
-
-#[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn test_read_only_shell_cleans_up_background_children_after_success() {
-    let executor = DockerExecutor::default()
-        .with_dockerfile(TEST_DOCKERFILE)
-        .with_context_path(".")
-        .with_image_name("test-read-only-shell-process-group-cleanup")
-        .to_owned()
-        .start()
-        .await
-        .unwrap();
-
-    let command = Command::read_only_shell(
-        r#"
-            sleep 30 &
-            printf '%s\n' "$!"
-        "#,
-    )
-    .with_timeout(Duration::from_secs(3));
-
-    let output = tokio::time::timeout(Duration::from_secs(8), executor.exec_cmd(&command))
-        .await
-        .expect("read-only command should return promptly")
-        .unwrap();
-    let child_pid = output.stdout.trim();
-    assert!(!child_pid.is_empty(), "expected command to print child pid");
-
-    let inspect = Command::shell(format!(
-        r#"if [ -r /proc/{child_pid}/stat ]; then awk '{{ print $3 }}' /proc/{child_pid}/stat; else echo gone; fi"#
-    ));
-    let child_state = executor.exec_cmd(&inspect).await.unwrap().to_string();
-    assert!(
-        child_state == "gone" || child_state == "Z",
-        "read-only background child should be gone or reaped as a zombie, got state {child_state:?}"
     );
 }
 

--- a/swiftide-docker-executor/src/tests.rs
+++ b/swiftide-docker-executor/src/tests.rs
@@ -933,6 +933,10 @@ async fn test_read_only_shell_reads_workdir_and_blocks_writes() {
                 if echo changed > readonly.txt; then echo allowed; else echo denied; fi
                 printf '\noutside='
                 if echo changed > /tmp/swiftide-readonly-outside; then echo allowed; else echo denied; fi
+                printf '\nchmod='
+                if chmod 600 readonly.txt; then echo allowed; else echo denied; fi
+                printf '\nchown='
+                if chown "$(id -u):$(id -g)" readonly.txt; then echo allowed; else echo denied; fi
                 printf '\nfinal='
                 cat readonly.txt
             "#,
@@ -951,6 +955,8 @@ async fn test_read_only_shell_reads_workdir_and_blocks_writes() {
             "read=original",
             "workdir=denied",
             "outside=denied",
+            "chmod=denied",
+            "chown=denied",
             "final=original"
         ]
     );

--- a/swiftide-docker-executor/src/tests.rs
+++ b/swiftide-docker-executor/src/tests.rs
@@ -907,6 +907,102 @@ print(1 + 2)"#;
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_read_only_shell_reads_workdir_and_blocks_writes() {
+    let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
+        .with_context_path(".")
+        .with_image_name("test-read-only-shell-boundaries")
+        .to_owned()
+        .start()
+        .await
+        .unwrap();
+
+    executor
+        .exec_cmd(&Command::shell(
+            "printf original > readonly.txt; rm -f /tmp/swiftide-readonly-outside",
+        ))
+        .await
+        .unwrap();
+
+    let output = executor
+        .exec_cmd(&Command::read_only_shell(
+            r#"
+                printf 'read='
+                cat readonly.txt
+                printf '\nworkdir='
+                if echo changed > readonly.txt; then echo allowed; else echo denied; fi
+                printf '\noutside='
+                if echo changed > /tmp/swiftide-readonly-outside; then echo allowed; else echo denied; fi
+                printf '\nfinal='
+                cat readonly.txt
+            "#,
+        ))
+        .await
+        .unwrap();
+
+    let lines = output
+        .stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        lines,
+        vec![
+            "read=original",
+            "workdir=denied",
+            "outside=denied",
+            "final=original"
+        ]
+    );
+
+    let verify = executor
+        .exec_cmd(&Command::shell(
+            "cat readonly.txt; test ! -e /tmp/swiftide-readonly-outside",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(verify.stdout, "original");
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn test_read_only_shell_preserves_env_home_and_shebang() {
+    let executor = DockerExecutor::default()
+        .with_dockerfile(TEST_DOCKERFILE)
+        .with_context_path(".")
+        .with_image_name("test-read-only-shell-env")
+        .with_env("HOME", "/tmp/swiftide-readonly-home")
+        .with_env("READ_ONLY_MARKER", "from-env")
+        .to_owned()
+        .start()
+        .await
+        .unwrap();
+
+    executor
+        .exec_cmd(&Command::shell(
+            "mkdir -p \"$HOME\"; printf 'export PROFILE_MARKER=from-profile\\n' > \"$HOME/.bash_profile\"",
+        ))
+        .await
+        .unwrap();
+
+    let output = executor
+        .exec_cmd(&Command::read_only_shell(
+            r#"#!/bin/bash
+printf 'env=%s\nprofile=%s\nhome=%s' "$READ_ONLY_MARKER" "$PROFILE_MARKER" "$HOME""#,
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        output.stdout.lines().collect::<Vec<_>>(),
+        vec![
+            "env=from-env",
+            "profile=from-profile",
+            "home=/tmp/swiftide-readonly-home"
+        ]
+    );
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn test_clear_env() {
     let executor = DockerExecutor::default()
         .with_dockerfile(TEST_DOCKERFILE)

--- a/swiftide-docker-service/Cargo.toml
+++ b/swiftide-docker-service/Cargo.toml
@@ -35,3 +35,6 @@ file-loader = ["dep:swiftide-indexing", "dep:swiftide-core"]
 
 [dev-dependencies]
 indoc = "2"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+landlock = "0.4.5"

--- a/swiftide-docker-service/proto/shell.proto
+++ b/swiftide-docker-service/proto/shell.proto
@@ -35,6 +35,15 @@ message ReadOnlyShellRequest {
 
   // Optional working directory for the command execution.
   optional string cwd = 3;
+
+  // Clears inherited environment variables before applying envs.
+  bool env_clear = 4;
+
+  // Environment variable names to remove before applying envs.
+  repeated string env_remove = 5;
+
+  // Environment variables to set for the read-only command.
+  map<string, string> envs = 6;
 }
 
 // The response message containing exit code, stdout, and stderr.

--- a/swiftide-docker-service/proto/shell.proto
+++ b/swiftide-docker-service/proto/shell.proto
@@ -6,6 +6,9 @@ package shell;
 service ShellExecutor {
   // Runs a shell command and returns exit code, stdout, and stderr.
   rpc ExecShell (ShellRequest) returns (ShellResponse) {}
+
+  // Runs a shell command with read-only access to the workspace.
+  rpc ExecReadOnlyShell (ReadOnlyShellRequest) returns (ShellResponse) {}
 }
 
 // The request message containing the command to run.
@@ -21,6 +24,17 @@ message ShellRequest {
 
   // Optional working directory for the command execution.
   optional string cwd = 7;
+}
+
+// The request message containing the read-only command to run.
+message ReadOnlyShellRequest {
+  string command = 1;
+
+  // Optional timeout in milliseconds for the command execution.
+  optional uint64 timeout_ms = 2;
+
+  // Optional working directory for the command execution.
+  optional string cwd = 3;
 }
 
 // The response message containing exit code, stdout, and stderr.

--- a/swiftide-docker-service/src/command_cleanup.rs
+++ b/swiftide-docker-service/src/command_cleanup.rs
@@ -5,7 +5,7 @@ use tokio::process::Child;
 
 const KILL_EINTR_RETRIES: usize = 3;
 
-/// Cleans up a command after it exceeded its deadline.
+/// Cleans up a command and its process group.
 pub(crate) struct CommandCleanup {
     child: Child,
     process_group: Option<ProcessGroup>,
@@ -14,19 +14,7 @@ pub(crate) struct CommandCleanup {
 impl CommandCleanup {
     /// Creates cleanup for a spawned command and its process group.
     pub(crate) fn new(child: Child) -> Self {
-        let process_group = child
-            .id()
-            .and_then(|pid| match ProcessGroup::from_child_pid(pid) {
-                Ok(process_group) => Some(process_group),
-                Err(err) => {
-                    tracing::warn!(
-                        pid,
-                        ?err,
-                        "Timed out command PID cannot be used as a process group"
-                    );
-                    None
-                }
-            });
+        let process_group = ProcessGroup::from_child(&child);
 
         Self {
             child,
@@ -37,15 +25,7 @@ impl CommandCleanup {
     /// Signals the command for termination and continues reaping it in the background.
     pub(crate) fn terminate(mut self) {
         if let Some(process_group) = self.process_group {
-            match process_group.kill() {
-                Ok(()) => {}
-                Err(err) if err.raw_os_error() == Some(ESRCH) => {
-                    tracing::debug!("Timed out command process group is already gone");
-                }
-                Err(err) => {
-                    tracing::warn!(?err, "Failed to kill timed out command process group");
-                }
-            }
+            process_group.kill_or_log("timed out command");
         }
 
         if let Err(err) = self.child.start_kill() {
@@ -74,11 +54,33 @@ impl CommandCleanup {
 }
 
 #[derive(Clone, Copy)]
-struct ProcessGroup {
+pub(crate) struct ProcessGroup {
     pid: pid_t,
 }
 
 impl ProcessGroup {
+    pub(crate) fn from_child(child: &Child) -> Option<Self> {
+        child.id().and_then(|pid| match Self::from_child_pid(pid) {
+            Ok(process_group) => Some(process_group),
+            Err(err) => {
+                tracing::warn!(pid, ?err, "Command PID cannot be used as a process group");
+                None
+            }
+        })
+    }
+
+    pub(crate) fn kill_or_log(self, context: &str) {
+        match self.kill() {
+            Ok(()) => {}
+            Err(err) if err.raw_os_error() == Some(ESRCH) => {
+                tracing::debug!(context, "Command process group is already gone");
+            }
+            Err(err) => {
+                tracing::warn!(?err, context, "Failed to kill command process group");
+            }
+        }
+    }
+
     fn from_child_pid(pid: u32) -> io::Result<Self> {
         let pid =
             pid_t::try_from(pid).map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;

--- a/swiftide-docker-service/src/command_cleanup.rs
+++ b/swiftide-docker-service/src/command_cleanup.rs
@@ -5,7 +5,7 @@ use tokio::process::Child;
 
 const KILL_EINTR_RETRIES: usize = 3;
 
-/// Cleans up a command and its process group.
+/// Cleans up a command after it exceeded its deadline.
 pub(crate) struct CommandCleanup {
     child: Child,
     process_group: Option<ProcessGroup>,
@@ -14,7 +14,19 @@ pub(crate) struct CommandCleanup {
 impl CommandCleanup {
     /// Creates cleanup for a spawned command and its process group.
     pub(crate) fn new(child: Child) -> Self {
-        let process_group = ProcessGroup::from_child(&child);
+        let process_group = child
+            .id()
+            .and_then(|pid| match ProcessGroup::from_child_pid(pid) {
+                Ok(process_group) => Some(process_group),
+                Err(err) => {
+                    tracing::warn!(
+                        pid,
+                        ?err,
+                        "Timed out command PID cannot be used as a process group"
+                    );
+                    None
+                }
+            });
 
         Self {
             child,
@@ -25,7 +37,15 @@ impl CommandCleanup {
     /// Signals the command for termination and continues reaping it in the background.
     pub(crate) fn terminate(mut self) {
         if let Some(process_group) = self.process_group {
-            process_group.kill_or_log("timed out command");
+            match process_group.kill() {
+                Ok(()) => {}
+                Err(err) if err.raw_os_error() == Some(ESRCH) => {
+                    tracing::debug!("Timed out command process group is already gone");
+                }
+                Err(err) => {
+                    tracing::warn!(?err, "Failed to kill timed out command process group");
+                }
+            }
         }
 
         if let Err(err) = self.child.start_kill() {
@@ -54,33 +74,11 @@ impl CommandCleanup {
 }
 
 #[derive(Clone, Copy)]
-pub(crate) struct ProcessGroup {
+struct ProcessGroup {
     pid: pid_t,
 }
 
 impl ProcessGroup {
-    pub(crate) fn from_child(child: &Child) -> Option<Self> {
-        child.id().and_then(|pid| match Self::from_child_pid(pid) {
-            Ok(process_group) => Some(process_group),
-            Err(err) => {
-                tracing::warn!(pid, ?err, "Command PID cannot be used as a process group");
-                None
-            }
-        })
-    }
-
-    pub(crate) fn kill_or_log(self, context: &str) {
-        match self.kill() {
-            Ok(()) => {}
-            Err(err) if err.raw_os_error() == Some(ESRCH) => {
-                tracing::debug!(context, "Command process group is already gone");
-            }
-            Err(err) => {
-                tracing::warn!(?err, context, "Failed to kill command process group");
-            }
-        }
-    }
-
     fn from_child_pid(pid: u32) -> io::Result<Self> {
         let pid =
             pid_t::try_from(pid).map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::io::Write as _;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Stdio;
@@ -24,9 +26,6 @@ use codegen::{ReadOnlyShellRequest, ShellRequest, ShellResponse};
 /// gRPC shell executor service implementation.
 #[derive(Debug, Default)]
 pub struct MyShellExecutor;
-
-#[cfg(target_os = "linux")]
-const READ_ONLY_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
 #[tonic::async_trait]
 impl ShellExecutor for MyShellExecutor {
@@ -213,6 +212,9 @@ impl ShellExecutor for MyShellExecutor {
     ) -> Result<Response<ShellResponse>, Status> {
         let ReadOnlyShellRequest {
             command,
+            env_clear,
+            env_remove,
+            envs,
             timeout_ms,
             cwd,
         } = request.into_inner();
@@ -237,8 +239,15 @@ impl ShellExecutor for MyShellExecutor {
             .map_err(|e| Status::internal(format!("Failed to protect read-only home: {e:?}")))?;
 
         let has_bash = Path::new("/bin/bash").exists();
-        let mut child =
-            spawn_read_only_command(&command, workdir_path, temp_home.path(), has_bash)?;
+        let mut child = spawn_read_only_command(
+            &command,
+            workdir_path,
+            temp_home.path(),
+            has_bash,
+            env_clear,
+            env_remove,
+            envs,
+        )?;
 
         let output = OutputCollector::capture(&mut child);
         let wait_future = child.wait();
@@ -312,10 +321,15 @@ fn spawn_read_only_command(
     workdir: &Path,
     temp_home: &Path,
     has_bash: bool,
+    env_clear: bool,
+    env_remove: Vec<String>,
+    envs: HashMap<String, String>,
 ) -> Result<tokio::process::Child, Status> {
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (command, workdir, temp_home, has_bash);
+        let _ = (
+            command, workdir, temp_home, has_bash, env_clear, env_remove, envs,
+        );
         Err(Status::unimplemented(
             "read-only shell is only supported on Linux",
         ))
@@ -323,23 +337,11 @@ fn spawn_read_only_command(
 
     #[cfg(target_os = "linux")]
     {
-        let shell = if has_bash { "/bin/bash" } else { "sh" };
-        let mut cmd = Command::new(shell);
+        let mut cmd = read_only_command(command, temp_home, has_bash)?;
+        apply_env_settings(&mut cmd, env_clear, env_remove.clone(), envs.clone());
+        apply_read_only_env_defaults(&mut cmd, &env_remove, &envs, temp_home);
 
-        cmd.env_clear()
-            .env("PATH", READ_ONLY_PATH)
-            .env("HOME", temp_home)
-            .env("TMPDIR", temp_home)
-            .env("CI", "true")
-            .env("GIT_OPTIONAL_LOCKS", "0");
-
-        if has_bash {
-            cmd.arg("--noprofile").arg("--norc");
-        }
-
-        cmd.arg("-c")
-            .arg(command)
-            .current_dir(workdir)
+        cmd.current_dir(workdir)
             .process_group(0)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
@@ -367,6 +369,77 @@ fn spawn_read_only_command(
             Status::internal(format!("Failed to start read-only command: {e:?}"))
         })
     }
+}
+
+#[cfg(target_os = "linux")]
+fn read_only_command(command: &str, temp_home: &Path, has_bash: bool) -> Result<Command, Status> {
+    let lines = command.lines().collect::<Vec<_>>();
+
+    if let Some(first_line) = lines.first()
+        && first_line.starts_with("#!")
+    {
+        let script_path = temp_home.join("script");
+        let mut script = std::fs::File::create(&script_path)
+            .map_err(|e| Status::internal(format!("Failed to create read-only script: {e:?}")))?;
+        script
+            .write_all(command.as_bytes())
+            .map_err(|e| Status::internal(format!("Failed to write read-only script: {e:?}")))?;
+        drop(script);
+        let permissions = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(&script_path, permissions).map_err(|e| {
+            Status::internal(format!("Failed to set read-only script permissions: {e:?}"))
+        })?;
+
+        if has_bash && is_bash_shebang(first_line) {
+            let mut cmd = Command::new("/bin/bash");
+            cmd.arg("--login");
+            if let Some(args) = shebang_args(first_line) {
+                cmd.args(args);
+            }
+            cmd.arg(script_path);
+            return Ok(cmd);
+        }
+
+        let (interpreter, args) = shebang_command(first_line)
+            .ok_or_else(|| Status::internal(format!("Failed to parse shebang: {first_line}")))?;
+        let mut cmd = Command::new(interpreter);
+        cmd.args(args);
+        cmd.arg(script_path);
+        return Ok(cmd);
+    }
+
+    let shell = if has_bash { "/bin/bash" } else { "sh" };
+    let mut cmd = Command::new(shell);
+    if has_bash {
+        cmd.arg("--login");
+    }
+    cmd.arg("-c").arg(command);
+    Ok(cmd)
+}
+
+#[cfg(target_os = "linux")]
+fn apply_read_only_env_defaults(
+    cmd: &mut Command,
+    env_remove: &[String],
+    envs: &HashMap<String, String>,
+    temp_home: &Path,
+) {
+    if should_set_read_only_default("TMPDIR", env_remove, envs) {
+        cmd.env("TMPDIR", temp_home);
+    }
+
+    if should_set_read_only_default("GIT_OPTIONAL_LOCKS", env_remove, envs) {
+        cmd.env("GIT_OPTIONAL_LOCKS", "0");
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn should_set_read_only_default(
+    key: &str,
+    env_remove: &[String],
+    envs: &HashMap<String, String>,
+) -> bool {
+    !envs.contains_key(key) && !env_remove.iter().any(|var| var == key)
 }
 
 #[cfg(target_os = "linux")]
@@ -549,6 +622,9 @@ mod tests {
             command: "sleep 60 &".to_string(),
             timeout_ms: Some(5_000),
             cwd: None,
+            env_clear: false,
+            env_remove: vec![],
+            envs: Default::default(),
         };
 
         let err = executor
@@ -566,6 +642,9 @@ mod tests {
             command: "pwd".to_string(),
             timeout_ms: Some(5_000),
             cwd: Some("/definitely/not/a/real/workdir".to_string()),
+            env_clear: false,
+            env_remove: vec![],
+            envs: Default::default(),
         };
 
         let err = executor
@@ -581,23 +660,34 @@ mod tests {
     async fn read_only_shell_allows_reads_and_temp_writes_but_blocks_workdir_writes() {
         let workdir = tempdir().unwrap();
         let file_path = workdir.path().join("existing.txt");
+        let outside_path = std::env::temp_dir().join(format!(
+            "swiftide-docker-service-readonly-outside-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&outside_path);
         fs::write(&file_path, "original").unwrap();
 
         let executor = MyShellExecutor;
         let req = ReadOnlyShellRequest {
-            command: indoc! {r#"
-                printf 'read='
-                cat existing.txt
-                printf '\ntmp='
-                echo temp-ok > "$TMPDIR/out" && cat "$TMPDIR/out"
-                printf '\nwrite='
-                if echo changed > existing.txt; then echo allowed; else echo denied; fi
-                printf '\nfinal='
-                cat existing.txt
-            "#}
-            .to_string(),
+            command: format!(
+                concat!(
+                    "printf 'read='\n",
+                    "cat existing.txt\n",
+                    "printf '\\ntmp='\n",
+                    "echo temp-ok > \"$TMPDIR/out\" && cat \"$TMPDIR/out\"\n",
+                    "printf '\\nworkdir='\n",
+                    "if echo changed > existing.txt; then echo allowed; else echo denied; fi\n",
+                    "printf '\\noutside='\n",
+                    "if echo changed > {outside}; then echo allowed; else echo denied; fi\n",
+                    "printf '\\nfinal=' && cat existing.txt"
+                ),
+                outside = outside_path.display()
+            ),
             timeout_ms: Some(5_000),
             cwd: Some(workdir.path().to_string_lossy().into_owned()),
+            env_clear: false,
+            env_remove: vec![],
+            envs: Default::default(),
         };
 
         let resp = executor
@@ -617,11 +707,66 @@ mod tests {
             vec![
                 "read=original",
                 "tmp=temp-ok",
-                "write=denied",
+                "workdir=denied",
+                "outside=denied",
                 "final=original"
             ]
         );
         assert_eq!(fs::read_to_string(file_path).unwrap(), "original");
+        assert!(!outside_path.exists());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn read_only_shell_preserves_env_home_and_shebang_behavior() {
+        if !Path::new("/bin/bash").exists() {
+            return;
+        }
+
+        let workdir = tempdir().unwrap();
+        let home = workdir.path().join("home");
+        fs::create_dir(&home).unwrap();
+        fs::write(
+            home.join(".bash_profile"),
+            "export PROFILE_MARKER=profile\n",
+        )
+        .unwrap();
+
+        let executor = MyShellExecutor;
+        let req = ReadOnlyShellRequest {
+            command: indoc! {r#"
+                #!/bin/bash
+                printf 'env=%s\nprofile=%s\nhome=%s' \
+                  "$READ_ONLY_MARKER" "$PROFILE_MARKER" "$HOME"
+            "#}
+            .to_string(),
+            timeout_ms: Some(5_000),
+            cwd: Some(workdir.path().to_string_lossy().into_owned()),
+            env_clear: false,
+            env_remove: vec![],
+            envs: [
+                ("HOME".to_string(), home.to_string_lossy().into_owned()),
+                ("READ_ONLY_MARKER".to_string(), "from-env".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+        };
+
+        let resp = executor
+            .exec_read_only_shell(Request::new(req))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(
+            resp.stdout.lines().collect::<Vec<_>>(),
+            vec![
+                "env=from-env",
+                "profile=profile",
+                &format!("home={}", home.display())
+            ]
+        );
     }
 
     #[tokio::test]

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -607,9 +607,19 @@ mod tests {
             .into_inner();
 
         assert_eq!(resp.exit_code, 0);
+        let lines = resp
+            .stdout
+            .lines()
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>();
         assert_eq!(
-            resp.stdout.trim(),
-            "read=original\ntmp=temp-ok\nwrite=denied\nfinal=original"
+            lines,
+            vec![
+                "read=original",
+                "tmp=temp-ok",
+                "write=denied",
+                "final=original"
+            ]
         );
         assert_eq!(fs::read_to_string(file_path).unwrap(), "original");
     }

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -10,7 +10,7 @@ use tonic::{Request, Response, Status};
 
 use crate::command_cleanup::CommandCleanup;
 use crate::output_collector::OutputCollector;
-use crate::read_only_sandbox;
+use crate::read_only_shell::{self, CommandEnv, ReadOnlyWorkdir};
 
 const OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -225,31 +225,12 @@ impl ShellExecutor for MyShellExecutor {
         }
 
         let timeout = timeout_ms.map(Duration::from_millis);
-        let workdir = cwd.unwrap_or_else(|| ".".to_string());
-        let workdir_path = Path::new(&workdir);
+        let workdir = ReadOnlyWorkdir::try_new(cwd.unwrap_or_else(|| ".".to_string()))?;
+        let env = CommandEnv::new(env_clear, env_remove, envs);
+        let mut command_handle = read_only_shell::spawn(&command, workdir, env)?;
 
-        ensure_read_only_workdir(workdir_path)?;
-
-        let temp_home = tempfile::Builder::new()
-            .prefix("swiftide-readonly-")
-            .tempdir_in("/tmp")
-            .map_err(|e| Status::internal(format!("Failed to create read-only home: {e:?}")))?;
-        std::fs::set_permissions(temp_home.path(), std::fs::Permissions::from_mode(0o700))
-            .map_err(|e| Status::internal(format!("Failed to protect read-only home: {e:?}")))?;
-
-        let has_bash = Path::new("/bin/bash").exists();
-        let mut child = read_only_sandbox::spawn_command(
-            &command,
-            workdir_path,
-            temp_home.path(),
-            has_bash,
-            env_clear,
-            env_remove,
-            envs,
-        )?;
-
-        let output = OutputCollector::capture(&mut child);
-        let wait_future = child.wait();
+        let output = OutputCollector::capture(command_handle.child_mut());
+        let wait_future = command_handle.child_mut().wait();
         let status = match timeout {
             Some(limit) => match time::timeout(limit, wait_future).await {
                 Ok(result) => result.map_err(|e| {
@@ -258,13 +239,12 @@ impl ShellExecutor for MyShellExecutor {
                 })?,
                 Err(_) => {
                     tracing::warn!(?limit, "Read-only command exceeded timeout; terminating");
-                    CommandCleanup::new(child).terminate();
+                    command_handle.terminate();
 
                     let (stdout_lines, stderr_lines) =
                         output.collect_with_timeout(OUTPUT_DRAIN_TIMEOUT).await;
                     let message = timeout_message(limit, &stdout_lines, &stderr_lines);
 
-                    drop(temp_home);
                     return Err(Status::deadline_exceeded(message));
                 }
             },
@@ -274,7 +254,8 @@ impl ShellExecutor for MyShellExecutor {
             })?,
         };
 
-        drop(temp_home);
+        command_handle.cleanup_process_group();
+        drop(command_handle);
 
         let (stdout_lines, stderr_lines) = output.collect().await;
         let response = ShellResponse {
@@ -313,31 +294,6 @@ fn apply_env_settings(
         tracing::info!(key, "setting environment variable");
         cmd.env(key, value);
     }
-}
-
-fn ensure_read_only_workdir(workdir: &Path) -> Result<(), Status> {
-    let metadata = std::fs::metadata(workdir).map_err(|e| {
-        Status::failed_precondition(format!(
-            "read-only shell workdir does not exist: {}: {e}",
-            workdir.display()
-        ))
-    })?;
-
-    if !metadata.is_dir() {
-        return Err(Status::failed_precondition(format!(
-            "read-only shell workdir is not a directory: {}",
-            workdir.display()
-        )));
-    }
-
-    if metadata.permissions().mode() & 0o002 != 0 {
-        return Err(Status::failed_precondition(format!(
-            "read-only shell workdir is world-writable: {}",
-            workdir.display()
-        )));
-    }
-
-    Ok(())
 }
 
 fn is_background(cmd: &str) -> bool {

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -399,6 +399,29 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     }
 
+    #[tokio::test]
+    async fn read_only_shell_requires_directory_workdir() {
+        let workdir = tempdir().unwrap();
+        let file_path = workdir.path().join("file");
+        fs::write(&file_path, "not a directory").unwrap();
+
+        let req = ReadOnlyShellRequest {
+            command: "pwd".to_string(),
+            timeout_ms: Some(5_000),
+            cwd: Some(file_path.to_string_lossy().into_owned()),
+            env_clear: false,
+            env_remove: vec![],
+            envs: Default::default(),
+        };
+
+        let err = MyShellExecutor
+            .exec_read_only_shell(Request::new(req))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
     #[cfg(target_os = "linux")]
     #[tokio::test]
     async fn read_only_shell_allows_reads_and_blocks_writes() {

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -10,7 +10,8 @@ use tonic::{Request, Response, Status};
 
 use crate::command_cleanup::CommandCleanup;
 use crate::output_collector::OutputCollector;
-use crate::read_only_shell::{self, CommandEnv, ReadOnlyWorkdir};
+use crate::read_only_shell;
+use crate::shell_script;
 
 const OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -108,18 +109,18 @@ impl ShellExecutor for MyShellExecutor {
             })?;
             temp_script = Some(script_dir);
 
-            let mut cmd = if has_bash && is_bash_shebang(first_line) {
+            let mut cmd = if has_bash && shell_script::is_bash_shebang(first_line) {
                 // Bash scripts should run as login shells so profile files are honored.
                 let mut cmd = Command::new("/bin/bash");
                 cmd.arg("--login");
-                if let Some(args) = shebang_args(first_line) {
+                if let Some(args) = shell_script::bash_args(first_line) {
                     cmd.args(args);
                 }
                 cmd.arg(&script_path);
                 cmd
             } else {
                 // Invoke the interpreter ourselves so Linux never execs a just-written temp file.
-                let (interpreter, args) = shebang_command(first_line).ok_or_else(|| {
+                let (interpreter, args) = shell_script::command(first_line).ok_or_else(|| {
                     Status::internal(format!("Failed to parse shebang: {first_line}"))
                 })?;
                 let mut cmd = Command::new(interpreter);
@@ -225,9 +226,9 @@ impl ShellExecutor for MyShellExecutor {
         }
 
         let timeout = timeout_ms.map(Duration::from_millis);
-        let workdir = ReadOnlyWorkdir::try_new(cwd.unwrap_or_else(|| ".".to_string()))?;
-        let env = CommandEnv::new(env_clear, env_remove, envs);
-        let mut command_handle = read_only_shell::spawn(&command, workdir, env)?;
+        let workdir = cwd.unwrap_or_else(|| ".".to_string());
+        let mut command_handle =
+            read_only_shell::spawn(&command, Path::new(&workdir), env_clear, env_remove, envs)?;
 
         let output = OutputCollector::capture(command_handle.child_mut());
         let wait_future = command_handle.child_mut().wait();
@@ -298,45 +299,6 @@ fn apply_env_settings(
 fn is_background(cmd: &str) -> bool {
     let trimmed = cmd.trim_end();
     trimmed.ends_with('&') && !trimmed.ends_with("\\&")
-}
-
-fn is_bash_shebang(line: &str) -> bool {
-    let Some(command) = line.strip_prefix("#!") else {
-        return false;
-    };
-
-    let mut parts = command.split_whitespace();
-    match (parts.next(), parts.next()) {
-        (Some(interpreter), _) if interpreter.ends_with("/bash") || interpreter == "bash" => true,
-        (Some(interpreter), Some(program))
-            if interpreter.ends_with("/env")
-                && (program == "bash" || program.ends_with("/bash")) =>
-        {
-            true
-        }
-        _ => false,
-    }
-}
-
-fn shebang_command(line: &str) -> Option<(&str, Vec<&str>)> {
-    let command = line.strip_prefix("#!")?;
-    let mut parts = command.split_whitespace();
-    let interpreter = parts.next()?;
-
-    Some((interpreter, parts.collect()))
-}
-
-fn shebang_args(line: &str) -> Option<Vec<&str>> {
-    let (interpreter, mut parts) = shebang_command(line)?;
-
-    if interpreter.ends_with("/env") {
-        if parts.is_empty() {
-            return None;
-        }
-        parts.remove(0);
-    }
-
-    Some(parts)
 }
 
 fn timeout_message(limit: Duration, stdout: &[String], stderr: &[String]) -> String {
@@ -435,133 +397,6 @@ mod tests {
             .unwrap_err();
 
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn read_only_shell_allows_reads_and_blocks_writes() {
-        let workdir = tempdir().unwrap();
-        let file_path = workdir.path().join("existing.txt");
-        let outside_path = std::env::temp_dir().join(format!(
-            "swiftide-docker-service-readonly-outside-{}",
-            std::process::id()
-        ));
-        let tmp_path = std::env::temp_dir().join(format!(
-            "swiftide-docker-service-readonly-tmp-{}",
-            std::process::id()
-        ));
-        let _ = fs::remove_file(&outside_path);
-        let _ = fs::remove_file(&tmp_path);
-        fs::write(&file_path, "original").unwrap();
-
-        let executor = MyShellExecutor;
-        let req = ReadOnlyShellRequest {
-            command: format!(
-                concat!(
-                    "printf 'read='\n",
-                    "cat existing.txt\n",
-                    "printf '\\nworkdir='\n",
-                    "if echo changed > existing.txt; then echo allowed; else echo denied; fi\n",
-                    "printf '\\noutside='\n",
-                    "if echo changed > {outside}; then echo allowed; else echo denied; fi\n",
-                    "printf '\\ntmp='\n",
-                    "if echo changed > {tmp}; then echo allowed; else echo denied; fi\n",
-                    "printf '\\nchmod='\n",
-                    "if chmod 600 existing.txt; then echo allowed; else echo denied; fi\n",
-                    "printf '\\nchown='\n",
-                    "if chown \"$(id -u):$(id -g)\" existing.txt; then echo allowed; else echo denied; fi\n",
-                    "printf '\\nfinal=' && cat existing.txt"
-                ),
-                outside = outside_path.display(),
-                tmp = tmp_path.display()
-            ),
-            timeout_ms: Some(5_000),
-            cwd: Some(workdir.path().to_string_lossy().into_owned()),
-            env_clear: false,
-            env_remove: vec![],
-            envs: Default::default(),
-        };
-
-        let resp = executor
-            .exec_read_only_shell(Request::new(req))
-            .await
-            .unwrap()
-            .into_inner();
-
-        assert_eq!(resp.exit_code, 0);
-        let lines = resp
-            .stdout
-            .lines()
-            .filter(|line| !line.is_empty())
-            .collect::<Vec<_>>();
-        assert_eq!(
-            lines,
-            vec![
-                "read=original",
-                "workdir=denied",
-                "outside=denied",
-                "tmp=denied",
-                "chmod=denied",
-                "chown=denied",
-                "final=original"
-            ]
-        );
-        assert_eq!(fs::read_to_string(file_path).unwrap(), "original");
-        assert!(!outside_path.exists());
-        assert!(!tmp_path.exists());
-    }
-
-    #[cfg(target_os = "linux")]
-    #[tokio::test]
-    async fn read_only_shell_preserves_env_home_and_shebang_behavior() {
-        if !Path::new("/bin/bash").exists() {
-            return;
-        }
-
-        let workdir = tempdir().unwrap();
-        let home = workdir.path().join("home");
-        fs::create_dir(&home).unwrap();
-        fs::write(
-            home.join(".bash_profile"),
-            "export PROFILE_MARKER=profile\n",
-        )
-        .unwrap();
-
-        let executor = MyShellExecutor;
-        let req = ReadOnlyShellRequest {
-            command: indoc! {r#"
-                #!/bin/bash
-                printf 'env=%s\nprofile=%s\nhome=%s' \
-                  "$READ_ONLY_MARKER" "$PROFILE_MARKER" "$HOME"
-            "#}
-            .to_string(),
-            timeout_ms: Some(5_000),
-            cwd: Some(workdir.path().to_string_lossy().into_owned()),
-            env_clear: false,
-            env_remove: vec![],
-            envs: [
-                ("HOME".to_string(), home.to_string_lossy().into_owned()),
-                ("READ_ONLY_MARKER".to_string(), "from-env".to_string()),
-            ]
-            .into_iter()
-            .collect(),
-        };
-
-        let resp = executor
-            .exec_read_only_shell(Request::new(req))
-            .await
-            .unwrap()
-            .into_inner();
-
-        assert_eq!(resp.exit_code, 0);
-        assert_eq!(
-            resp.stdout.lines().collect::<Vec<_>>(),
-            vec![
-                "env=from-env",
-                "profile=profile",
-                &format!("home={}", home.display())
-            ]
-        );
     }
 
     #[tokio::test]

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -254,7 +254,6 @@ impl ShellExecutor for MyShellExecutor {
             })?,
         };
 
-        command_handle.cleanup_process_group();
         drop(command_handle);
 
         let (stdout_lines, stderr_lines) = output.collect().await;
@@ -440,14 +439,19 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[tokio::test]
-    async fn read_only_shell_allows_reads_and_temp_writes_but_blocks_workdir_writes() {
+    async fn read_only_shell_allows_reads_and_blocks_writes() {
         let workdir = tempdir().unwrap();
         let file_path = workdir.path().join("existing.txt");
         let outside_path = std::env::temp_dir().join(format!(
             "swiftide-docker-service-readonly-outside-{}",
             std::process::id()
         ));
+        let tmp_path = std::env::temp_dir().join(format!(
+            "swiftide-docker-service-readonly-tmp-{}",
+            std::process::id()
+        ));
         let _ = fs::remove_file(&outside_path);
+        let _ = fs::remove_file(&tmp_path);
         fs::write(&file_path, "original").unwrap();
 
         let executor = MyShellExecutor;
@@ -456,19 +460,20 @@ mod tests {
                 concat!(
                     "printf 'read='\n",
                     "cat existing.txt\n",
-                    "printf '\\ntmp='\n",
-                    "echo temp-ok > \"$TMPDIR/out\" && cat \"$TMPDIR/out\"\n",
                     "printf '\\nworkdir='\n",
                     "if echo changed > existing.txt; then echo allowed; else echo denied; fi\n",
                     "printf '\\noutside='\n",
                     "if echo changed > {outside}; then echo allowed; else echo denied; fi\n",
+                    "printf '\\ntmp='\n",
+                    "if echo changed > {tmp}; then echo allowed; else echo denied; fi\n",
                     "printf '\\nchmod='\n",
                     "if chmod 600 existing.txt; then echo allowed; else echo denied; fi\n",
                     "printf '\\nchown='\n",
                     "if chown \"$(id -u):$(id -g)\" existing.txt; then echo allowed; else echo denied; fi\n",
                     "printf '\\nfinal=' && cat existing.txt"
                 ),
-                outside = outside_path.display()
+                outside = outside_path.display(),
+                tmp = tmp_path.display()
             ),
             timeout_ms: Some(5_000),
             cwd: Some(workdir.path().to_string_lossy().into_owned()),
@@ -493,9 +498,9 @@ mod tests {
             lines,
             vec![
                 "read=original",
-                "tmp=temp-ok",
                 "workdir=denied",
                 "outside=denied",
+                "tmp=denied",
                 "chmod=denied",
                 "chown=denied",
                 "final=original"
@@ -503,6 +508,7 @@ mod tests {
         );
         assert_eq!(fs::read_to_string(file_path).unwrap(), "original");
         assert!(!outside_path.exists());
+        assert!(!tmp_path.exists());
     }
 
     #[cfg(target_os = "linux")]

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-#[cfg(target_os = "linux")]
-use std::io::Write as _;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::process::Stdio;
@@ -12,6 +10,7 @@ use tonic::{Request, Response, Status};
 
 use crate::command_cleanup::CommandCleanup;
 use crate::output_collector::OutputCollector;
+use crate::read_only_sandbox;
 
 const OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -239,7 +238,7 @@ impl ShellExecutor for MyShellExecutor {
             .map_err(|e| Status::internal(format!("Failed to protect read-only home: {e:?}")))?;
 
         let has_bash = Path::new("/bin/bash").exists();
-        let mut child = spawn_read_only_command(
+        let mut child = read_only_sandbox::spawn_command(
             &command,
             workdir_path,
             temp_home.path(),
@@ -314,178 +313,6 @@ fn apply_env_settings(
         tracing::info!(key, "setting environment variable");
         cmd.env(key, value);
     }
-}
-
-fn spawn_read_only_command(
-    command: &str,
-    workdir: &Path,
-    temp_home: &Path,
-    has_bash: bool,
-    env_clear: bool,
-    env_remove: Vec<String>,
-    envs: HashMap<String, String>,
-) -> Result<tokio::process::Child, Status> {
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (
-            command, workdir, temp_home, has_bash, env_clear, env_remove, envs,
-        );
-        Err(Status::unimplemented(
-            "read-only shell is only supported on Linux",
-        ))
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        let mut cmd = read_only_command(command, temp_home, has_bash)?;
-        apply_env_settings(&mut cmd, env_clear, env_remove.clone(), envs.clone());
-        apply_read_only_env_defaults(&mut cmd, &env_remove, &envs, temp_home);
-
-        cmd.current_dir(workdir)
-            .process_group(0)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let landlock_ruleset = create_read_only_landlock(temp_home)?;
-        let mut landlock_ruleset = Some(landlock_ruleset);
-
-        // Safety: pre_exec runs in the child process after fork and before exec.
-        // The ruleset is created before spawning; the child only restricts itself
-        // before it runs the shell, so the service process is not affected.
-        unsafe {
-            cmd.pre_exec(move || {
-                let Some(ruleset) = landlock_ruleset.take() else {
-                    return Err(std::io::Error::other(
-                        "Landlock read-only ruleset was already consumed",
-                    ));
-                };
-                enforce_read_only_landlock(ruleset)
-            });
-        }
-
-        cmd.spawn().map_err(|e| {
-            tracing::error!(error = ?e, "Failed to start read-only command");
-            Status::internal(format!("Failed to start read-only command: {e:?}"))
-        })
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn read_only_command(command: &str, temp_home: &Path, has_bash: bool) -> Result<Command, Status> {
-    let lines = command.lines().collect::<Vec<_>>();
-
-    if let Some(first_line) = lines.first()
-        && first_line.starts_with("#!")
-    {
-        let script_path = temp_home.join("script");
-        let mut script = std::fs::File::create(&script_path)
-            .map_err(|e| Status::internal(format!("Failed to create read-only script: {e:?}")))?;
-        script
-            .write_all(command.as_bytes())
-            .map_err(|e| Status::internal(format!("Failed to write read-only script: {e:?}")))?;
-        drop(script);
-        let permissions = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&script_path, permissions).map_err(|e| {
-            Status::internal(format!("Failed to set read-only script permissions: {e:?}"))
-        })?;
-
-        if has_bash && is_bash_shebang(first_line) {
-            let mut cmd = Command::new("/bin/bash");
-            cmd.arg("--login");
-            if let Some(args) = shebang_args(first_line) {
-                cmd.args(args);
-            }
-            cmd.arg(script_path);
-            return Ok(cmd);
-        }
-
-        let (interpreter, args) = shebang_command(first_line)
-            .ok_or_else(|| Status::internal(format!("Failed to parse shebang: {first_line}")))?;
-        let mut cmd = Command::new(interpreter);
-        cmd.args(args);
-        cmd.arg(script_path);
-        return Ok(cmd);
-    }
-
-    let shell = if has_bash { "/bin/bash" } else { "sh" };
-    let mut cmd = Command::new(shell);
-    if has_bash {
-        cmd.arg("--login");
-    }
-    cmd.arg("-c").arg(command);
-    Ok(cmd)
-}
-
-#[cfg(target_os = "linux")]
-fn apply_read_only_env_defaults(
-    cmd: &mut Command,
-    env_remove: &[String],
-    envs: &HashMap<String, String>,
-    temp_home: &Path,
-) {
-    if should_set_read_only_default("TMPDIR", env_remove, envs) {
-        cmd.env("TMPDIR", temp_home);
-    }
-
-    if should_set_read_only_default("GIT_OPTIONAL_LOCKS", env_remove, envs) {
-        cmd.env("GIT_OPTIONAL_LOCKS", "0");
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn should_set_read_only_default(
-    key: &str,
-    env_remove: &[String],
-    envs: &HashMap<String, String>,
-) -> bool {
-    !envs.contains_key(key) && !env_remove.iter().any(|var| var == key)
-}
-
-#[cfg(target_os = "linux")]
-fn create_read_only_landlock(temp_home: &Path) -> std::io::Result<landlock::RulesetCreated> {
-    use landlock::{
-        ABI, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
-        RulesetCreatedAttr,
-    };
-
-    // ABI V3 includes the write-like operations agents commonly use to mutate a
-    // checkout, including file writes, creates, deletes, renames, and truncation.
-    let abi = ABI::V3;
-    let write_access = AccessFs::from_write(abi);
-
-    Ruleset::default()
-        .set_compatibility(CompatLevel::HardRequirement)
-        .handle_access(write_access)
-        .map_err(landlock_error)?
-        .create()
-        .map_err(landlock_error)?
-        .add_rule(PathBeneath::new(
-            PathFd::new(temp_home).map_err(landlock_error)?,
-            write_access,
-        ))
-        .map_err(landlock_error)
-}
-
-#[cfg(target_os = "linux")]
-fn enforce_read_only_landlock(ruleset: landlock::RulesetCreated) -> std::io::Result<()> {
-    use landlock::RulesetStatus;
-
-    let status = ruleset.restrict_self().map_err(landlock_error)?;
-
-    if status.ruleset == RulesetStatus::FullyEnforced {
-        Ok(())
-    } else {
-        Err(std::io::Error::other(format!(
-            "Landlock read-only ruleset was not fully enforced: {:?}",
-            status
-        )))
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn landlock_error(error: impl std::fmt::Display) -> std::io::Error {
-    std::io::Error::other(error.to_string())
 }
 
 fn ensure_read_only_workdir(workdir: &Path) -> Result<(), Status> {
@@ -679,6 +506,10 @@ mod tests {
                     "if echo changed > existing.txt; then echo allowed; else echo denied; fi\n",
                     "printf '\\noutside='\n",
                     "if echo changed > {outside}; then echo allowed; else echo denied; fi\n",
+                    "printf '\\nchmod='\n",
+                    "if chmod 600 existing.txt; then echo allowed; else echo denied; fi\n",
+                    "printf '\\nchown='\n",
+                    "if chown \"$(id -u):$(id -g)\" existing.txt; then echo allowed; else echo denied; fi\n",
                     "printf '\\nfinal=' && cat existing.txt"
                 ),
                 outside = outside_path.display()
@@ -709,6 +540,8 @@ mod tests {
                 "tmp=temp-ok",
                 "workdir=denied",
                 "outside=denied",
+                "chmod=denied",
+                "chown=denied",
                 "final=original"
             ]
         );

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -399,6 +399,53 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::FailedPrecondition);
     }
 
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn read_only_shell_allows_reads_and_blocks_writes() {
+        let workdir = tempdir().unwrap();
+        let file_path = workdir.path().join("existing.txt");
+        let outside_path = std::env::temp_dir().join(format!(
+            "swiftide-docker-service-readonly-outside-{}",
+            std::process::id()
+        ));
+        let tmp_path = std::env::temp_dir().join(format!(
+            "swiftide-docker-service-readonly-tmp-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_file(&outside_path);
+        let _ = fs::remove_file(&tmp_path);
+        fs::write(&file_path, "original").unwrap();
+
+        let req = ReadOnlyShellRequest {
+            command: format!(
+                "cat existing.txt\n\
+                 if echo changed > existing.txt; then echo workdir-allowed; fi\n\
+                 if echo changed > {outside}; then echo outside-allowed; fi\n\
+                 if echo changed > {tmp}; then echo tmp-allowed; fi\n\
+                 if chmod 600 existing.txt; then echo chmod-allowed; fi",
+                outside = outside_path.display(),
+                tmp = tmp_path.display()
+            ),
+            timeout_ms: Some(5_000),
+            cwd: Some(workdir.path().to_string_lossy().into_owned()),
+            env_clear: false,
+            env_remove: vec![],
+            envs: Default::default(),
+        };
+
+        let resp = MyShellExecutor
+            .exec_read_only_shell(Request::new(req))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(resp.stdout.lines().collect::<Vec<_>>(), vec!["original"]);
+        assert_eq!(fs::read_to_string(file_path).unwrap(), "original");
+        assert!(!outside_path.exists());
+        assert!(!tmp_path.exists());
+    }
+
     #[tokio::test]
     async fn test_exec_shell_shebang_env_sh() {
         let executor = MyShellExecutor;

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -19,11 +19,14 @@ pub mod codegen {
 }
 
 use codegen::shell_executor_server::ShellExecutor;
-use codegen::{ShellRequest, ShellResponse};
+use codegen::{ReadOnlyShellRequest, ShellRequest, ShellResponse};
 
 /// gRPC shell executor service implementation.
 #[derive(Debug, Default)]
 pub struct MyShellExecutor;
+
+#[cfg(target_os = "linux")]
+const READ_ONLY_PATH: &str = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";
 
 #[tonic::async_trait]
 impl ShellExecutor for MyShellExecutor {
@@ -202,6 +205,84 @@ impl ShellExecutor for MyShellExecutor {
 
         Ok(Response::new(response))
     }
+
+    #[tracing::instrument(skip_all)]
+    async fn exec_read_only_shell(
+        &self,
+        request: Request<ReadOnlyShellRequest>,
+    ) -> Result<Response<ShellResponse>, Status> {
+        let ReadOnlyShellRequest {
+            command,
+            timeout_ms,
+            cwd,
+        } = request.into_inner();
+
+        if is_background(&command) {
+            return Err(Status::invalid_argument(
+                "read-only shell does not support background commands",
+            ));
+        }
+
+        let timeout = timeout_ms.map(Duration::from_millis);
+        let workdir = cwd.unwrap_or_else(|| ".".to_string());
+        let workdir_path = Path::new(&workdir);
+
+        ensure_read_only_workdir(workdir_path)?;
+
+        let temp_home = tempfile::Builder::new()
+            .prefix("swiftide-readonly-")
+            .tempdir_in("/tmp")
+            .map_err(|e| Status::internal(format!("Failed to create read-only home: {e:?}")))?;
+        std::fs::set_permissions(temp_home.path(), std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| Status::internal(format!("Failed to protect read-only home: {e:?}")))?;
+
+        let has_bash = Path::new("/bin/bash").exists();
+        let mut child =
+            spawn_read_only_command(&command, workdir_path, temp_home.path(), has_bash)?;
+
+        let output = OutputCollector::capture(&mut child);
+        let wait_future = child.wait();
+        let status = match timeout {
+            Some(limit) => match time::timeout(limit, wait_future).await {
+                Ok(result) => result.map_err(|e| {
+                    tracing::error!(error = ?e, "Failed to wait for read-only command");
+                    Status::internal(format!("Failed to wait for read-only command: {e:?}"))
+                })?,
+                Err(_) => {
+                    tracing::warn!(?limit, "Read-only command exceeded timeout; terminating");
+                    CommandCleanup::new(child).terminate();
+
+                    let (stdout_lines, stderr_lines) =
+                        output.collect_with_timeout(OUTPUT_DRAIN_TIMEOUT).await;
+                    let message = timeout_message(limit, &stdout_lines, &stderr_lines);
+
+                    drop(temp_home);
+                    return Err(Status::deadline_exceeded(message));
+                }
+            },
+            None => wait_future.await.map_err(|e| {
+                tracing::error!(error = ?e, "Failed to wait for read-only command");
+                Status::internal(format!("Failed to wait for read-only command: {e:?}"))
+            })?,
+        };
+
+        drop(temp_home);
+
+        let (stdout_lines, stderr_lines) = output.collect().await;
+        let response = ShellResponse {
+            exit_code: status.code().unwrap_or(-1),
+            stdout: stdout_lines.join("\n"),
+            stderr: stderr_lines.join("\n"),
+        };
+
+        tracing::info!(
+            command,
+            exit_code = response.exit_code,
+            "Read-only command executed"
+        );
+
+        Ok(Response::new(response))
+    }
 }
 
 fn apply_env_settings(
@@ -224,6 +305,139 @@ fn apply_env_settings(
         tracing::info!(key, "setting environment variable");
         cmd.env(key, value);
     }
+}
+
+fn spawn_read_only_command(
+    command: &str,
+    workdir: &Path,
+    temp_home: &Path,
+    has_bash: bool,
+) -> Result<tokio::process::Child, Status> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (command, workdir, temp_home, has_bash);
+        Err(Status::unimplemented(
+            "read-only shell is only supported on Linux",
+        ))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let shell = if has_bash { "/bin/bash" } else { "sh" };
+        let mut cmd = Command::new(shell);
+
+        cmd.env_clear()
+            .env("PATH", READ_ONLY_PATH)
+            .env("HOME", temp_home)
+            .env("TMPDIR", temp_home)
+            .env("CI", "true")
+            .env("GIT_OPTIONAL_LOCKS", "0");
+
+        if has_bash {
+            cmd.arg("--noprofile").arg("--norc");
+        }
+
+        cmd.arg("-c")
+            .arg(command)
+            .current_dir(workdir)
+            .process_group(0)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let landlock_ruleset = create_read_only_landlock(temp_home)?;
+        let mut landlock_ruleset = Some(landlock_ruleset);
+
+        // Safety: pre_exec runs in the child process after fork and before exec.
+        // The ruleset is created before spawning; the child only restricts itself
+        // before it runs the shell, so the service process is not affected.
+        unsafe {
+            cmd.pre_exec(move || {
+                let Some(ruleset) = landlock_ruleset.take() else {
+                    return Err(std::io::Error::other(
+                        "Landlock read-only ruleset was already consumed",
+                    ));
+                };
+                enforce_read_only_landlock(ruleset)
+            });
+        }
+
+        cmd.spawn().map_err(|e| {
+            tracing::error!(error = ?e, "Failed to start read-only command");
+            Status::internal(format!("Failed to start read-only command: {e:?}"))
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn create_read_only_landlock(temp_home: &Path) -> std::io::Result<landlock::RulesetCreated> {
+    use landlock::{
+        ABI, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
+        RulesetCreatedAttr,
+    };
+
+    // ABI V3 includes the write-like operations agents commonly use to mutate a
+    // checkout, including file writes, creates, deletes, renames, and truncation.
+    let abi = ABI::V3;
+    let write_access = AccessFs::from_write(abi);
+
+    Ruleset::default()
+        .set_compatibility(CompatLevel::HardRequirement)
+        .handle_access(write_access)
+        .map_err(landlock_error)?
+        .create()
+        .map_err(landlock_error)?
+        .add_rule(PathBeneath::new(
+            PathFd::new(temp_home).map_err(landlock_error)?,
+            write_access,
+        ))
+        .map_err(landlock_error)
+}
+
+#[cfg(target_os = "linux")]
+fn enforce_read_only_landlock(ruleset: landlock::RulesetCreated) -> std::io::Result<()> {
+    use landlock::RulesetStatus;
+
+    let status = ruleset.restrict_self().map_err(landlock_error)?;
+
+    if status.ruleset == RulesetStatus::FullyEnforced {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "Landlock read-only ruleset was not fully enforced: {:?}",
+            status
+        )))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn landlock_error(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::other(error.to_string())
+}
+
+fn ensure_read_only_workdir(workdir: &Path) -> Result<(), Status> {
+    let metadata = std::fs::metadata(workdir).map_err(|e| {
+        Status::failed_precondition(format!(
+            "read-only shell workdir does not exist: {}: {e}",
+            workdir.display()
+        ))
+    })?;
+
+    if !metadata.is_dir() {
+        return Err(Status::failed_precondition(format!(
+            "read-only shell workdir is not a directory: {}",
+            workdir.display()
+        )));
+    }
+
+    if metadata.permissions().mode() & 0o002 != 0 {
+        return Err(Status::failed_precondition(format!(
+            "read-only shell workdir is world-writable: {}",
+            workdir.display()
+        )));
+    }
+
+    Ok(())
 }
 
 fn is_background(cmd: &str) -> bool {
@@ -299,7 +513,9 @@ fn push_lines(message: &mut String, lines: &[String]) {
 #[cfg(test)]
 mod tests {
     use super::codegen::shell_executor_server::ShellExecutor;
-    use super::{MyShellExecutor, codegen::ShellRequest, is_background};
+    use super::{
+        MyShellExecutor, codegen::ReadOnlyShellRequest, codegen::ShellRequest, is_background,
+    };
     use indoc::indoc;
     use std::fs;
     use std::path::Path;
@@ -324,6 +540,78 @@ mod tests {
     #[test]
     fn test_is_not_background() {
         assert!(!is_background("echo hello"));
+    }
+
+    #[tokio::test]
+    async fn read_only_shell_rejects_background_commands() {
+        let executor = MyShellExecutor;
+        let req = ReadOnlyShellRequest {
+            command: "sleep 60 &".to_string(),
+            timeout_ms: Some(5_000),
+            cwd: None,
+        };
+
+        let err = executor
+            .exec_read_only_shell(Request::new(req))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn read_only_shell_requires_existing_workdir() {
+        let executor = MyShellExecutor;
+        let req = ReadOnlyShellRequest {
+            command: "pwd".to_string(),
+            timeout_ms: Some(5_000),
+            cwd: Some("/definitely/not/a/real/workdir".to_string()),
+        };
+
+        let err = executor
+            .exec_read_only_shell(Request::new(req))
+            .await
+            .unwrap_err();
+
+        assert_eq!(err.code(), tonic::Code::FailedPrecondition);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn read_only_shell_allows_reads_and_temp_writes_but_blocks_workdir_writes() {
+        let workdir = tempdir().unwrap();
+        let file_path = workdir.path().join("existing.txt");
+        fs::write(&file_path, "original").unwrap();
+
+        let executor = MyShellExecutor;
+        let req = ReadOnlyShellRequest {
+            command: indoc! {r#"
+                printf 'read='
+                cat existing.txt
+                printf '\ntmp='
+                echo temp-ok > "$TMPDIR/out" && cat "$TMPDIR/out"
+                printf '\nwrite='
+                if echo changed > existing.txt; then echo allowed; else echo denied; fi
+                printf '\nfinal='
+                cat existing.txt
+            "#}
+            .to_string(),
+            timeout_ms: Some(5_000),
+            cwd: Some(workdir.path().to_string_lossy().into_owned()),
+        };
+
+        let resp = executor
+            .exec_read_only_shell(Request::new(req))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(
+            resp.stdout.trim(),
+            "read=original\ntmp=temp-ok\nwrite=denied\nfinal=original"
+        );
+        assert_eq!(fs::read_to_string(file_path).unwrap(), "original");
     }
 
     #[tokio::test]

--- a/swiftide-docker-service/src/executor.rs
+++ b/swiftide-docker-service/src/executor.rs
@@ -446,6 +446,58 @@ mod tests {
         assert!(!tmp_path.exists());
     }
 
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn read_only_shell_preserves_env_home_and_shebang_behavior() {
+        if !Path::new("/bin/bash").exists() {
+            return;
+        }
+
+        let workdir = tempdir().unwrap();
+        let home = workdir.path().join("home");
+        fs::create_dir(&home).unwrap();
+        fs::write(
+            home.join(".bash_profile"),
+            "export PROFILE_MARKER=profile\n",
+        )
+        .unwrap();
+
+        let req = ReadOnlyShellRequest {
+            command: indoc! {r#"
+                #!/bin/bash
+                printf 'env=%s\nprofile=%s\nhome=%s' \
+                  "$READ_ONLY_MARKER" "$PROFILE_MARKER" "$HOME"
+            "#}
+            .to_string(),
+            timeout_ms: Some(5_000),
+            cwd: Some(workdir.path().to_string_lossy().into_owned()),
+            env_clear: false,
+            env_remove: vec![],
+            envs: [
+                ("HOME".to_string(), home.to_string_lossy().into_owned()),
+                ("READ_ONLY_MARKER".to_string(), "from-env".to_string()),
+            ]
+            .into_iter()
+            .collect(),
+        };
+
+        let resp = MyShellExecutor
+            .exec_read_only_shell(Request::new(req))
+            .await
+            .unwrap()
+            .into_inner();
+
+        assert_eq!(resp.exit_code, 0);
+        assert_eq!(
+            resp.stdout.lines().collect::<Vec<_>>(),
+            vec![
+                "env=from-env",
+                "profile=profile",
+                &format!("home={}", home.display())
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn test_exec_shell_shebang_env_sh() {
         let executor = MyShellExecutor;

--- a/swiftide-docker-service/src/main.rs
+++ b/swiftide-docker-service/src/main.rs
@@ -8,6 +8,7 @@ mod executor;
 mod loader;
 mod output_collector;
 mod read_only_sandbox;
+mod read_only_shell;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/swiftide-docker-service/src/main.rs
+++ b/swiftide-docker-service/src/main.rs
@@ -7,6 +7,7 @@ mod executor;
 #[cfg(feature = "file-loader")]
 mod loader;
 mod output_collector;
+mod read_only_sandbox;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/swiftide-docker-service/src/main.rs
+++ b/swiftide-docker-service/src/main.rs
@@ -9,6 +9,7 @@ mod loader;
 mod output_collector;
 mod read_only_sandbox;
 mod read_only_shell;
+mod shell_script;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/swiftide-docker-service/src/read_only_sandbox.rs
+++ b/swiftide-docker-service/src/read_only_sandbox.rs
@@ -1,166 +1,32 @@
-use std::{collections::HashMap, path::Path};
+#[cfg(target_os = "linux")]
+use {std::path::Path, tokio::process::Command};
 
 #[cfg(target_os = "linux")]
-use std::{io::Write as _, os::unix::fs::PermissionsExt as _, process::Stdio};
+pub(crate) fn apply_to_command(cmd: &mut Command, scratch: &Path) -> std::io::Result<()> {
+    let landlock_ruleset = create_read_only_landlock(scratch)?;
+    let mut landlock_ruleset = Some(landlock_ruleset);
 
-use tokio::process::Child;
-#[cfg(target_os = "linux")]
-use tokio::process::Command;
-use tonic::Status;
+    // Safety: pre_exec runs in the child process after fork and before exec.
+    // The child installs both sandbox layers before it runs the shell; the
+    // service process is not restricted.
+    unsafe {
+        cmd.pre_exec(move || {
+            let Some(ruleset) = landlock_ruleset.take() else {
+                return Err(std::io::Error::other(
+                    "Landlock read-only ruleset was already consumed",
+                ));
+            };
 
-pub(crate) fn spawn_command(
-    command: &str,
-    workdir: &Path,
-    temp_home: &Path,
-    has_bash: bool,
-    env_clear: bool,
-    env_remove: Vec<String>,
-    envs: HashMap<String, String>,
-) -> Result<Child, Status> {
-    #[cfg(not(target_os = "linux"))]
-    {
-        let _ = (
-            command, workdir, temp_home, has_bash, env_clear, env_remove, envs,
-        );
-        Err(Status::unimplemented(
-            "read-only shell is only supported on Linux",
-        ))
+            enforce_read_only_landlock(ruleset)?;
+            install_metadata_mutation_seccomp()
+        });
     }
 
-    #[cfg(target_os = "linux")]
-    {
-        let mut cmd = read_only_command(command, temp_home, has_bash)?;
-        apply_env_settings(&mut cmd, env_clear, env_remove.clone(), envs.clone());
-        apply_read_only_env_defaults(&mut cmd, &env_remove, &envs, temp_home);
-
-        cmd.current_dir(workdir)
-            .process_group(0)
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped());
-
-        let landlock_ruleset = create_read_only_landlock(temp_home)?;
-        let mut landlock_ruleset = Some(landlock_ruleset);
-
-        // Safety: pre_exec runs in the child process after fork and before exec.
-        // The child installs both sandbox layers before it runs the shell; the
-        // service process is not restricted.
-        unsafe {
-            cmd.pre_exec(move || {
-                let Some(ruleset) = landlock_ruleset.take() else {
-                    return Err(std::io::Error::other(
-                        "Landlock read-only ruleset was already consumed",
-                    ));
-                };
-
-                enforce_read_only_landlock(ruleset)?;
-                install_metadata_mutation_seccomp()
-            });
-        }
-
-        cmd.spawn().map_err(|e| {
-            tracing::error!(error = ?e, "Failed to start read-only command");
-            Status::internal(format!("Failed to start read-only command: {e:?}"))
-        })
-    }
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
-fn apply_env_settings(
-    cmd: &mut Command,
-    env_clear: bool,
-    env_remove: Vec<String>,
-    envs: HashMap<String, String>,
-) {
-    if env_clear {
-        tracing::info!("clearing environment variables");
-        cmd.env_clear();
-    }
-
-    for var in env_remove {
-        tracing::info!(var, "clearing environment variable");
-        cmd.env_remove(var);
-    }
-
-    for (key, value) in envs {
-        tracing::info!(key, "setting environment variable");
-        cmd.env(key, value);
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn read_only_command(command: &str, temp_home: &Path, has_bash: bool) -> Result<Command, Status> {
-    let lines = command.lines().collect::<Vec<_>>();
-
-    if let Some(first_line) = lines.first()
-        && first_line.starts_with("#!")
-    {
-        let script_path = temp_home.join("script");
-        let mut script = std::fs::File::create(&script_path)
-            .map_err(|e| Status::internal(format!("Failed to create read-only script: {e:?}")))?;
-        script
-            .write_all(command.as_bytes())
-            .map_err(|e| Status::internal(format!("Failed to write read-only script: {e:?}")))?;
-        drop(script);
-        let permissions = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&script_path, permissions).map_err(|e| {
-            Status::internal(format!("Failed to set read-only script permissions: {e:?}"))
-        })?;
-
-        if has_bash && is_bash_shebang(first_line) {
-            let mut cmd = Command::new("/bin/bash");
-            cmd.arg("--login");
-            if let Some(args) = shebang_args(first_line) {
-                cmd.args(args);
-            }
-            cmd.arg(script_path);
-            return Ok(cmd);
-        }
-
-        let (interpreter, args) = shebang_command(first_line)
-            .ok_or_else(|| Status::internal(format!("Failed to parse shebang: {first_line}")))?;
-        let mut cmd = Command::new(interpreter);
-        cmd.args(args);
-        cmd.arg(script_path);
-        return Ok(cmd);
-    }
-
-    let shell = if has_bash { "/bin/bash" } else { "sh" };
-    let mut cmd = Command::new(shell);
-    if has_bash {
-        cmd.arg("--login");
-    }
-    cmd.arg("-c").arg(command);
-    Ok(cmd)
-}
-
-#[cfg(target_os = "linux")]
-fn apply_read_only_env_defaults(
-    cmd: &mut Command,
-    env_remove: &[String],
-    envs: &HashMap<String, String>,
-    temp_home: &Path,
-) {
-    if should_set_read_only_default("TMPDIR", env_remove, envs) {
-        cmd.env("TMPDIR", temp_home);
-    }
-
-    if should_set_read_only_default("GIT_OPTIONAL_LOCKS", env_remove, envs) {
-        cmd.env("GIT_OPTIONAL_LOCKS", "0");
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn should_set_read_only_default(
-    key: &str,
-    env_remove: &[String],
-    envs: &HashMap<String, String>,
-) -> bool {
-    !envs.contains_key(key) && !env_remove.iter().any(|var| var == key)
-}
-
-#[cfg(target_os = "linux")]
-fn create_read_only_landlock(temp_home: &Path) -> std::io::Result<landlock::RulesetCreated> {
+fn create_read_only_landlock(scratch: &Path) -> std::io::Result<landlock::RulesetCreated> {
     use landlock::{
         ABI, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
         RulesetCreatedAttr,
@@ -176,7 +42,7 @@ fn create_read_only_landlock(temp_home: &Path) -> std::io::Result<landlock::Rule
         .create()
         .map_err(sandbox_error)?
         .add_rule(PathBeneath::new(
-            PathFd::new(temp_home).map_err(sandbox_error)?,
+            PathFd::new(scratch).map_err(sandbox_error)?,
             write_access,
         ))
         .map_err(sandbox_error)
@@ -200,13 +66,20 @@ fn enforce_read_only_landlock(ruleset: landlock::RulesetCreated) -> std::io::Res
 
 #[cfg(target_os = "linux")]
 fn install_metadata_mutation_seccomp() -> std::io::Result<()> {
-    let mut filter = Vec::with_capacity(metadata_mutation_syscalls().len() * 2 + 2);
+    let syscalls = metadata_mutation_syscalls();
+    if syscalls.is_empty() {
+        return Err(std::io::Error::other(
+            "read-only shell metadata seccomp is not supported on this architecture",
+        ));
+    }
+
+    let mut filter = Vec::with_capacity(syscalls.len() * 2 + 2);
     filter.push(bpf_stmt(
         (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16,
         std::mem::offset_of!(libc::seccomp_data, nr) as u32,
     ));
 
-    for syscall in metadata_mutation_syscalls() {
+    for syscall in syscalls {
         filter.push(bpf_jump(
             (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16,
             *syscall as u32,
@@ -306,95 +179,4 @@ fn metadata_mutation_syscalls() -> &'static [libc::c_long] {
 #[cfg(target_os = "linux")]
 fn sandbox_error(error: impl std::fmt::Display) -> std::io::Error {
     std::io::Error::other(error.to_string())
-}
-
-#[cfg(target_os = "linux")]
-fn is_bash_shebang(line: &str) -> bool {
-    let Some(command) = line.strip_prefix("#!") else {
-        return false;
-    };
-
-    let mut parts = command.split_whitespace();
-    match (parts.next(), parts.next()) {
-        (Some(interpreter), _) if interpreter.ends_with("/bash") || interpreter == "bash" => true,
-        (Some(interpreter), Some(program))
-            if interpreter.ends_with("/env")
-                && (program == "bash" || program.ends_with("/bash")) =>
-        {
-            true
-        }
-        _ => false,
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn shebang_command(line: &str) -> Option<(&str, Vec<&str>)> {
-    let command = line.strip_prefix("#!")?;
-    let mut parts = command.split_whitespace();
-    let interpreter = parts.next()?;
-
-    Some((interpreter, parts.collect()))
-}
-
-#[cfg(target_os = "linux")]
-fn shebang_args(line: &str) -> Option<Vec<&str>> {
-    let (interpreter, mut parts) = shebang_command(line)?;
-
-    if interpreter.ends_with("/env") {
-        if parts.is_empty() {
-            return None;
-        }
-        parts.remove(0);
-    }
-
-    Some(parts)
-}
-
-#[cfg(all(test, target_os = "linux"))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn detects_bash_shebangs() {
-        assert!(is_bash_shebang("#!/bin/bash"));
-        assert!(is_bash_shebang("#!/usr/bin/env bash -e"));
-        assert!(!is_bash_shebang("#!/usr/bin/env python3"));
-        assert!(!is_bash_shebang("echo not a shebang"));
-    }
-
-    #[test]
-    fn parses_shebang_command_and_args() {
-        assert_eq!(
-            shebang_command("#!/usr/bin/env python3 -u"),
-            Some(("/usr/bin/env", vec!["python3", "-u"]))
-        );
-        assert_eq!(shebang_command("echo nope"), None);
-        assert_eq!(shebang_args("#!/usr/bin/env bash -e"), Some(vec!["-e"]));
-        assert_eq!(shebang_args("#!/bin/bash -e"), Some(vec!["-e"]));
-    }
-
-    #[test]
-    fn read_only_defaults_respect_explicit_env_settings() {
-        let mut envs = HashMap::new();
-        let env_remove = vec!["GIT_OPTIONAL_LOCKS".to_string()];
-
-        assert!(should_set_read_only_default("TMPDIR", &env_remove, &envs));
-        assert!(!should_set_read_only_default(
-            "GIT_OPTIONAL_LOCKS",
-            &env_remove,
-            &envs
-        ));
-
-        envs.insert("TMPDIR".to_string(), "/custom-tmp".to_string());
-        assert!(!should_set_read_only_default("TMPDIR", &env_remove, &envs));
-    }
-
-    #[test]
-    fn metadata_filter_includes_chmod_and_chown_syscalls() {
-        let syscalls = metadata_mutation_syscalls();
-
-        assert!(syscalls.contains(&libc::SYS_chmod));
-        assert!(syscalls.contains(&libc::SYS_chown));
-        assert!(syscalls.contains(&libc::SYS_utimensat));
-    }
 }

--- a/swiftide-docker-service/src/read_only_sandbox.rs
+++ b/swiftide-docker-service/src/read_only_sandbox.rs
@@ -1,9 +1,9 @@
 #[cfg(target_os = "linux")]
-use {std::path::Path, tokio::process::Command};
+use tokio::process::Command;
 
 #[cfg(target_os = "linux")]
-pub(crate) fn apply_to_command(cmd: &mut Command, scratch: &Path) -> std::io::Result<()> {
-    let landlock_ruleset = create_read_only_landlock(scratch)?;
+pub(crate) fn apply_to_command(cmd: &mut Command) -> std::io::Result<()> {
+    let landlock_ruleset = create_read_only_landlock()?;
     let mut landlock_ruleset = Some(landlock_ruleset);
 
     // Safety: pre_exec runs in the child process after fork and before exec.
@@ -26,11 +26,8 @@ pub(crate) fn apply_to_command(cmd: &mut Command, scratch: &Path) -> std::io::Re
 }
 
 #[cfg(target_os = "linux")]
-fn create_read_only_landlock(scratch: &Path) -> std::io::Result<landlock::RulesetCreated> {
-    use landlock::{
-        ABI, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
-        RulesetCreatedAttr,
-    };
+fn create_read_only_landlock() -> std::io::Result<landlock::RulesetCreated> {
+    use landlock::{ABI, AccessFs, CompatLevel, Compatible, Ruleset, RulesetAttr};
 
     let abi = ABI::V3;
     let write_access = AccessFs::from_write(abi);
@@ -40,11 +37,6 @@ fn create_read_only_landlock(scratch: &Path) -> std::io::Result<landlock::Rulese
         .handle_access(write_access)
         .map_err(sandbox_error)?
         .create()
-        .map_err(sandbox_error)?
-        .add_rule(PathBeneath::new(
-            PathFd::new(scratch).map_err(sandbox_error)?,
-            write_access,
-        ))
         .map_err(sandbox_error)
 }
 

--- a/swiftide-docker-service/src/read_only_sandbox.rs
+++ b/swiftide-docker-service/src/read_only_sandbox.rs
@@ -1,0 +1,400 @@
+use std::{collections::HashMap, path::Path};
+
+#[cfg(target_os = "linux")]
+use std::{io::Write as _, os::unix::fs::PermissionsExt as _, process::Stdio};
+
+use tokio::process::Child;
+#[cfg(target_os = "linux")]
+use tokio::process::Command;
+use tonic::Status;
+
+pub(crate) fn spawn_command(
+    command: &str,
+    workdir: &Path,
+    temp_home: &Path,
+    has_bash: bool,
+    env_clear: bool,
+    env_remove: Vec<String>,
+    envs: HashMap<String, String>,
+) -> Result<Child, Status> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let _ = (
+            command, workdir, temp_home, has_bash, env_clear, env_remove, envs,
+        );
+        Err(Status::unimplemented(
+            "read-only shell is only supported on Linux",
+        ))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let mut cmd = read_only_command(command, temp_home, has_bash)?;
+        apply_env_settings(&mut cmd, env_clear, env_remove.clone(), envs.clone());
+        apply_read_only_env_defaults(&mut cmd, &env_remove, &envs, temp_home);
+
+        cmd.current_dir(workdir)
+            .process_group(0)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let landlock_ruleset = create_read_only_landlock(temp_home)?;
+        let mut landlock_ruleset = Some(landlock_ruleset);
+
+        // Safety: pre_exec runs in the child process after fork and before exec.
+        // The child installs both sandbox layers before it runs the shell; the
+        // service process is not restricted.
+        unsafe {
+            cmd.pre_exec(move || {
+                let Some(ruleset) = landlock_ruleset.take() else {
+                    return Err(std::io::Error::other(
+                        "Landlock read-only ruleset was already consumed",
+                    ));
+                };
+
+                enforce_read_only_landlock(ruleset)?;
+                install_metadata_mutation_seccomp()
+            });
+        }
+
+        cmd.spawn().map_err(|e| {
+            tracing::error!(error = ?e, "Failed to start read-only command");
+            Status::internal(format!("Failed to start read-only command: {e:?}"))
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn apply_env_settings(
+    cmd: &mut Command,
+    env_clear: bool,
+    env_remove: Vec<String>,
+    envs: HashMap<String, String>,
+) {
+    if env_clear {
+        tracing::info!("clearing environment variables");
+        cmd.env_clear();
+    }
+
+    for var in env_remove {
+        tracing::info!(var, "clearing environment variable");
+        cmd.env_remove(var);
+    }
+
+    for (key, value) in envs {
+        tracing::info!(key, "setting environment variable");
+        cmd.env(key, value);
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_only_command(command: &str, temp_home: &Path, has_bash: bool) -> Result<Command, Status> {
+    let lines = command.lines().collect::<Vec<_>>();
+
+    if let Some(first_line) = lines.first()
+        && first_line.starts_with("#!")
+    {
+        let script_path = temp_home.join("script");
+        let mut script = std::fs::File::create(&script_path)
+            .map_err(|e| Status::internal(format!("Failed to create read-only script: {e:?}")))?;
+        script
+            .write_all(command.as_bytes())
+            .map_err(|e| Status::internal(format!("Failed to write read-only script: {e:?}")))?;
+        drop(script);
+        let permissions = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(&script_path, permissions).map_err(|e| {
+            Status::internal(format!("Failed to set read-only script permissions: {e:?}"))
+        })?;
+
+        if has_bash && is_bash_shebang(first_line) {
+            let mut cmd = Command::new("/bin/bash");
+            cmd.arg("--login");
+            if let Some(args) = shebang_args(first_line) {
+                cmd.args(args);
+            }
+            cmd.arg(script_path);
+            return Ok(cmd);
+        }
+
+        let (interpreter, args) = shebang_command(first_line)
+            .ok_or_else(|| Status::internal(format!("Failed to parse shebang: {first_line}")))?;
+        let mut cmd = Command::new(interpreter);
+        cmd.args(args);
+        cmd.arg(script_path);
+        return Ok(cmd);
+    }
+
+    let shell = if has_bash { "/bin/bash" } else { "sh" };
+    let mut cmd = Command::new(shell);
+    if has_bash {
+        cmd.arg("--login");
+    }
+    cmd.arg("-c").arg(command);
+    Ok(cmd)
+}
+
+#[cfg(target_os = "linux")]
+fn apply_read_only_env_defaults(
+    cmd: &mut Command,
+    env_remove: &[String],
+    envs: &HashMap<String, String>,
+    temp_home: &Path,
+) {
+    if should_set_read_only_default("TMPDIR", env_remove, envs) {
+        cmd.env("TMPDIR", temp_home);
+    }
+
+    if should_set_read_only_default("GIT_OPTIONAL_LOCKS", env_remove, envs) {
+        cmd.env("GIT_OPTIONAL_LOCKS", "0");
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn should_set_read_only_default(
+    key: &str,
+    env_remove: &[String],
+    envs: &HashMap<String, String>,
+) -> bool {
+    !envs.contains_key(key) && !env_remove.iter().any(|var| var == key)
+}
+
+#[cfg(target_os = "linux")]
+fn create_read_only_landlock(temp_home: &Path) -> std::io::Result<landlock::RulesetCreated> {
+    use landlock::{
+        ABI, AccessFs, CompatLevel, Compatible, PathBeneath, PathFd, Ruleset, RulesetAttr,
+        RulesetCreatedAttr,
+    };
+
+    let abi = ABI::V3;
+    let write_access = AccessFs::from_write(abi);
+
+    Ruleset::default()
+        .set_compatibility(CompatLevel::HardRequirement)
+        .handle_access(write_access)
+        .map_err(sandbox_error)?
+        .create()
+        .map_err(sandbox_error)?
+        .add_rule(PathBeneath::new(
+            PathFd::new(temp_home).map_err(sandbox_error)?,
+            write_access,
+        ))
+        .map_err(sandbox_error)
+}
+
+#[cfg(target_os = "linux")]
+fn enforce_read_only_landlock(ruleset: landlock::RulesetCreated) -> std::io::Result<()> {
+    use landlock::RulesetStatus;
+
+    let status = ruleset.restrict_self().map_err(sandbox_error)?;
+
+    if status.ruleset == RulesetStatus::FullyEnforced {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "Landlock read-only ruleset was not fully enforced: {:?}",
+            status
+        )))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn install_metadata_mutation_seccomp() -> std::io::Result<()> {
+    let mut filter = Vec::with_capacity(metadata_mutation_syscalls().len() * 2 + 2);
+    filter.push(bpf_stmt(
+        (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16,
+        std::mem::offset_of!(libc::seccomp_data, nr) as u32,
+    ));
+
+    for syscall in metadata_mutation_syscalls() {
+        filter.push(bpf_jump(
+            (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16,
+            *syscall as u32,
+            0,
+            1,
+        ));
+        filter.push(bpf_stmt(
+            (libc::BPF_RET | libc::BPF_K) as u16,
+            libc::SECCOMP_RET_ERRNO | libc::EPERM as u32,
+        ));
+    }
+
+    filter.push(bpf_stmt(
+        (libc::BPF_RET | libc::BPF_K) as u16,
+        libc::SECCOMP_RET_ALLOW,
+    ));
+
+    let mut program = libc::sock_fprog {
+        len: filter
+            .len()
+            .try_into()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?,
+        filter: filter.as_mut_ptr(),
+    };
+
+    // Safety: prctl is called with documented SECCOMP arguments. The filter
+    // pointer stays valid for the duration of the syscall.
+    unsafe {
+        if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        if libc::prctl(
+            libc::PR_SET_SECCOMP,
+            libc::SECCOMP_MODE_FILTER,
+            &mut program as *mut libc::sock_fprog,
+            0,
+            0,
+        ) != 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn bpf_stmt(code: u16, k: u32) -> libc::sock_filter {
+    // Safety: libc constructs a plain BPF statement value from scalar inputs.
+    unsafe { libc::BPF_STMT(code, k) }
+}
+
+#[cfg(target_os = "linux")]
+fn bpf_jump(code: u16, k: u32, jt: u8, jf: u8) -> libc::sock_filter {
+    // Safety: libc constructs a plain BPF jump value from scalar inputs.
+    unsafe { libc::BPF_JUMP(code, k, jt, jf) }
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn metadata_mutation_syscalls() -> &'static [libc::c_long] {
+    &[
+        libc::SYS_chmod,
+        libc::SYS_fchmod,
+        libc::SYS_fchmodat,
+        libc::SYS_fchmodat2,
+        libc::SYS_chown,
+        libc::SYS_fchown,
+        libc::SYS_lchown,
+        libc::SYS_fchownat,
+        libc::SYS_utime,
+        libc::SYS_utimes,
+        libc::SYS_futimesat,
+        libc::SYS_utimensat,
+    ]
+}
+
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+fn metadata_mutation_syscalls() -> &'static [libc::c_long] {
+    &[
+        libc::SYS_fchmod,
+        libc::SYS_fchmodat,
+        libc::SYS_fchown,
+        libc::SYS_fchownat,
+        libc::SYS_utimensat,
+    ]
+}
+
+#[cfg(all(
+    target_os = "linux",
+    not(any(target_arch = "x86_64", target_arch = "aarch64"))
+))]
+fn metadata_mutation_syscalls() -> &'static [libc::c_long] {
+    &[]
+}
+
+#[cfg(target_os = "linux")]
+fn sandbox_error(error: impl std::fmt::Display) -> std::io::Error {
+    std::io::Error::other(error.to_string())
+}
+
+#[cfg(target_os = "linux")]
+fn is_bash_shebang(line: &str) -> bool {
+    let Some(command) = line.strip_prefix("#!") else {
+        return false;
+    };
+
+    let mut parts = command.split_whitespace();
+    match (parts.next(), parts.next()) {
+        (Some(interpreter), _) if interpreter.ends_with("/bash") || interpreter == "bash" => true,
+        (Some(interpreter), Some(program))
+            if interpreter.ends_with("/env")
+                && (program == "bash" || program.ends_with("/bash")) =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn shebang_command(line: &str) -> Option<(&str, Vec<&str>)> {
+    let command = line.strip_prefix("#!")?;
+    let mut parts = command.split_whitespace();
+    let interpreter = parts.next()?;
+
+    Some((interpreter, parts.collect()))
+}
+
+#[cfg(target_os = "linux")]
+fn shebang_args(line: &str) -> Option<Vec<&str>> {
+    let (interpreter, mut parts) = shebang_command(line)?;
+
+    if interpreter.ends_with("/env") {
+        if parts.is_empty() {
+            return None;
+        }
+        parts.remove(0);
+    }
+
+    Some(parts)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_bash_shebangs() {
+        assert!(is_bash_shebang("#!/bin/bash"));
+        assert!(is_bash_shebang("#!/usr/bin/env bash -e"));
+        assert!(!is_bash_shebang("#!/usr/bin/env python3"));
+        assert!(!is_bash_shebang("echo not a shebang"));
+    }
+
+    #[test]
+    fn parses_shebang_command_and_args() {
+        assert_eq!(
+            shebang_command("#!/usr/bin/env python3 -u"),
+            Some(("/usr/bin/env", vec!["python3", "-u"]))
+        );
+        assert_eq!(shebang_command("echo nope"), None);
+        assert_eq!(shebang_args("#!/usr/bin/env bash -e"), Some(vec!["-e"]));
+        assert_eq!(shebang_args("#!/bin/bash -e"), Some(vec!["-e"]));
+    }
+
+    #[test]
+    fn read_only_defaults_respect_explicit_env_settings() {
+        let mut envs = HashMap::new();
+        let env_remove = vec!["GIT_OPTIONAL_LOCKS".to_string()];
+
+        assert!(should_set_read_only_default("TMPDIR", &env_remove, &envs));
+        assert!(!should_set_read_only_default(
+            "GIT_OPTIONAL_LOCKS",
+            &env_remove,
+            &envs
+        ));
+
+        envs.insert("TMPDIR".to_string(), "/custom-tmp".to_string());
+        assert!(!should_set_read_only_default("TMPDIR", &env_remove, &envs));
+    }
+
+    #[test]
+    fn metadata_filter_includes_chmod_and_chown_syscalls() {
+        let syscalls = metadata_mutation_syscalls();
+
+        assert!(syscalls.contains(&libc::SYS_chmod));
+        assert!(syscalls.contains(&libc::SYS_chown));
+        assert!(syscalls.contains(&libc::SYS_utimensat));
+    }
+}

--- a/swiftide-docker-service/src/read_only_sandbox.rs
+++ b/swiftide-docker-service/src/read_only_sandbox.rs
@@ -188,6 +188,11 @@ mod tests {
     use super::*;
 
     #[test]
+    fn landlock_ruleset_tracks_write_access_without_writable_paths() {
+        create_read_only_landlock().expect("read-only Landlock ruleset should be creatable");
+    }
+
+    #[test]
     fn metadata_mutation_filter_denies_each_metadata_syscall() {
         let filter =
             metadata_mutation_seccomp_filter().expect("metadata mutation filter should build");
@@ -210,5 +215,15 @@ mod tests {
             .count();
 
         assert_eq!(deny_metadata_syscalls, metadata_mutation_syscalls().len());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn metadata_mutation_syscalls_include_common_file_metadata_changes() {
+        let syscalls = metadata_mutation_syscalls();
+
+        assert!(syscalls.contains(&libc::SYS_chmod));
+        assert!(syscalls.contains(&libc::SYS_chown));
+        assert!(syscalls.contains(&libc::SYS_utimensat));
     }
 }

--- a/swiftide-docker-service/src/read_only_sandbox.rs
+++ b/swiftide-docker-service/src/read_only_sandbox.rs
@@ -128,14 +128,17 @@ fn metadata_mutation_seccomp_filter() -> std::io::Result<Vec<libc::sock_filter>>
 
 #[cfg(target_os = "linux")]
 fn bpf_stmt(code: u16, k: u32) -> libc::sock_filter {
-    // Safety: libc constructs a plain BPF statement value from scalar inputs.
-    unsafe { libc::BPF_STMT(code, k) }
+    libc::sock_filter {
+        code,
+        jt: 0,
+        jf: 0,
+        k,
+    }
 }
 
 #[cfg(target_os = "linux")]
 fn bpf_jump(code: u16, k: u32, jt: u8, jf: u8) -> libc::sock_filter {
-    // Safety: libc constructs a plain BPF jump value from scalar inputs.
-    unsafe { libc::BPF_JUMP(code, k, jt, jf) }
+    libc::sock_filter { code, jt, jf, k }
 }
 
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
@@ -185,11 +188,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn landlock_ruleset_tracks_write_access_without_writable_paths() {
-        create_read_only_landlock().expect("read-only Landlock ruleset should be creatable");
-    }
-
-    #[test]
     fn metadata_mutation_filter_denies_each_metadata_syscall() {
         let filter =
             metadata_mutation_seccomp_filter().expect("metadata mutation filter should build");
@@ -212,15 +210,5 @@ mod tests {
             .count();
 
         assert_eq!(deny_metadata_syscalls, metadata_mutation_syscalls().len());
-    }
-
-    #[cfg(target_arch = "x86_64")]
-    #[test]
-    fn metadata_mutation_syscalls_include_common_file_metadata_changes() {
-        let syscalls = metadata_mutation_syscalls();
-
-        assert!(syscalls.contains(&libc::SYS_chmod));
-        assert!(syscalls.contains(&libc::SYS_chown));
-        assert!(syscalls.contains(&libc::SYS_utimensat));
     }
 }

--- a/swiftide-docker-service/src/read_only_sandbox.rs
+++ b/swiftide-docker-service/src/read_only_sandbox.rs
@@ -58,6 +58,40 @@ fn enforce_read_only_landlock(ruleset: landlock::RulesetCreated) -> std::io::Res
 
 #[cfg(target_os = "linux")]
 fn install_metadata_mutation_seccomp() -> std::io::Result<()> {
+    let mut filter = metadata_mutation_seccomp_filter()?;
+
+    let mut program = libc::sock_fprog {
+        len: filter
+            .len()
+            .try_into()
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?,
+        filter: filter.as_mut_ptr(),
+    };
+
+    // Safety: prctl is called with documented SECCOMP arguments. The filter
+    // pointer stays valid for the duration of the syscall.
+    unsafe {
+        if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        if libc::prctl(
+            libc::PR_SET_SECCOMP,
+            libc::SECCOMP_MODE_FILTER,
+            &mut program as *mut libc::sock_fprog,
+            0,
+            0,
+        ) != 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn metadata_mutation_seccomp_filter() -> std::io::Result<Vec<libc::sock_filter>> {
     let syscalls = metadata_mutation_syscalls();
     if syscalls.is_empty() {
         return Err(std::io::Error::other(
@@ -89,34 +123,7 @@ fn install_metadata_mutation_seccomp() -> std::io::Result<()> {
         libc::SECCOMP_RET_ALLOW,
     ));
 
-    let mut program = libc::sock_fprog {
-        len: filter
-            .len()
-            .try_into()
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidInput, err))?,
-        filter: filter.as_mut_ptr(),
-    };
-
-    // Safety: prctl is called with documented SECCOMP arguments. The filter
-    // pointer stays valid for the duration of the syscall.
-    unsafe {
-        if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
-            return Err(std::io::Error::last_os_error());
-        }
-
-        if libc::prctl(
-            libc::PR_SET_SECCOMP,
-            libc::SECCOMP_MODE_FILTER,
-            &mut program as *mut libc::sock_fprog,
-            0,
-            0,
-        ) != 0
-        {
-            return Err(std::io::Error::last_os_error());
-        }
-    }
-
-    Ok(())
+    Ok(filter)
 }
 
 #[cfg(target_os = "linux")]
@@ -171,4 +178,49 @@ fn metadata_mutation_syscalls() -> &'static [libc::c_long] {
 #[cfg(target_os = "linux")]
 fn sandbox_error(error: impl std::fmt::Display) -> std::io::Error {
     std::io::Error::other(error.to_string())
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn landlock_ruleset_tracks_write_access_without_writable_paths() {
+        create_read_only_landlock().expect("read-only Landlock ruleset should be creatable");
+    }
+
+    #[test]
+    fn metadata_mutation_filter_denies_each_metadata_syscall() {
+        let filter =
+            metadata_mutation_seccomp_filter().expect("metadata mutation filter should build");
+
+        assert_eq!(
+            filter.first().map(|instruction| instruction.code),
+            Some((libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16)
+        );
+        assert_eq!(
+            filter.last().map(|instruction| instruction.k),
+            Some(libc::SECCOMP_RET_ALLOW)
+        );
+
+        let deny_metadata_syscalls = filter
+            .iter()
+            .filter(|instruction| {
+                instruction.code == (libc::BPF_RET | libc::BPF_K) as u16
+                    && instruction.k == (libc::SECCOMP_RET_ERRNO | libc::EPERM as u32)
+            })
+            .count();
+
+        assert_eq!(deny_metadata_syscalls, metadata_mutation_syscalls().len());
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn metadata_mutation_syscalls_include_common_file_metadata_changes() {
+        let syscalls = metadata_mutation_syscalls();
+
+        assert!(syscalls.contains(&libc::SYS_chmod));
+        assert!(syscalls.contains(&libc::SYS_chown));
+        assert!(syscalls.contains(&libc::SYS_utimensat));
+    }
 }

--- a/swiftide-docker-service/src/read_only_shell.rs
+++ b/swiftide-docker-service/src/read_only_shell.rs
@@ -6,47 +6,8 @@ use tonic::Status;
 use crate::command_cleanup::CommandCleanup;
 #[cfg(target_os = "linux")]
 use crate::read_only_sandbox;
-
-pub(crate) struct ReadOnlyWorkdir {
-    path: std::path::PathBuf,
-}
-
-impl ReadOnlyWorkdir {
-    pub(crate) fn try_new(path: impl Into<std::path::PathBuf>) -> Result<Self, Status> {
-        let path = path.into();
-        let metadata = std::fs::metadata(&path).map_err(|e| {
-            Status::failed_precondition(format!(
-                "read-only shell workdir does not exist: {}: {e}",
-                path.display()
-            ))
-        })?;
-
-        if !metadata.is_dir() {
-            return Err(Status::failed_precondition(format!(
-                "read-only shell workdir is not a directory: {}",
-                path.display()
-            )));
-        }
-
-        Ok(Self { path })
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-}
-
-pub(crate) struct CommandEnv {
-    clear: bool,
-    remove: Vec<String>,
-    set: HashMap<String, String>,
-}
-
-impl CommandEnv {
-    pub(crate) fn new(clear: bool, remove: Vec<String>, set: HashMap<String, String>) -> Self {
-        Self { clear, remove, set }
-    }
-}
+#[cfg(target_os = "linux")]
+use crate::shell_script;
 
 pub(crate) struct SpawnedReadOnlyCommand {
     child: Child,
@@ -66,13 +27,16 @@ impl SpawnedReadOnlyCommand {
 
 pub(crate) fn spawn(
     command: &str,
-    workdir: ReadOnlyWorkdir,
-    env: CommandEnv,
+    workdir: &Path,
+    env_clear: bool,
+    env_remove: Vec<String>,
+    envs: HashMap<String, String>,
 ) -> Result<SpawnedReadOnlyCommand, Status> {
+    validate_workdir(workdir)?;
+
     #[cfg(not(target_os = "linux"))]
     {
-        let CommandEnv { clear, remove, set } = env;
-        let _ = (command, workdir.path(), clear, remove, set);
+        let _ = (command, workdir, env_clear, env_remove, envs);
         Err(Status::unimplemented(
             "read-only shell is only supported on Linux",
         ))
@@ -84,8 +48,8 @@ pub(crate) fn spawn(
         let prepared = read_only_command(command, has_bash)?;
         let mut cmd = prepared.command;
 
-        env.apply(&mut cmd);
-        cmd.current_dir(workdir.path())
+        apply_env(&mut cmd, env_clear, env_remove, envs);
+        cmd.current_dir(workdir)
             .process_group(0)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
@@ -103,6 +67,24 @@ pub(crate) fn spawn(
             child,
             _script_dir: prepared.script_dir,
         })
+    }
+}
+
+fn validate_workdir(path: &Path) -> Result<(), Status> {
+    let metadata = std::fs::metadata(path).map_err(|e| {
+        Status::failed_precondition(format!(
+            "read-only shell workdir does not exist: {}: {e}",
+            path.display()
+        ))
+    })?;
+
+    if metadata.is_dir() {
+        Ok(())
+    } else {
+        Err(Status::failed_precondition(format!(
+            "read-only shell workdir is not a directory: {}",
+            path.display()
+        )))
     }
 }
 
@@ -141,30 +123,32 @@ impl ScriptDir {
 }
 
 #[cfg(target_os = "linux")]
-impl CommandEnv {
-    fn apply(&self, cmd: &mut tokio::process::Command) {
-        if self.clear {
-            tracing::info!("clearing environment variables");
-            cmd.env_clear();
-        }
-
-        for var in &self.remove {
-            tracing::info!(var, "clearing environment variable");
-            cmd.env_remove(var);
-        }
-
-        for (key, value) in &self.set {
-            tracing::info!(key, "setting environment variable");
-            cmd.env(key, value);
-        }
-
-        if self.should_set_default("GIT_OPTIONAL_LOCKS") {
-            cmd.env("GIT_OPTIONAL_LOCKS", "0");
-        }
+fn apply_env(
+    cmd: &mut tokio::process::Command,
+    clear: bool,
+    remove: Vec<String>,
+    set: HashMap<String, String>,
+) {
+    if clear {
+        tracing::info!("clearing environment variables");
+        cmd.env_clear();
     }
 
-    fn should_set_default(&self, key: &str) -> bool {
-        !self.set.contains_key(key) && !self.remove.iter().any(|var| var == key)
+    let set_git_optional_locks = !set.contains_key("GIT_OPTIONAL_LOCKS")
+        && !remove.iter().any(|var| var == "GIT_OPTIONAL_LOCKS");
+
+    for var in remove {
+        tracing::info!(var, "clearing environment variable");
+        cmd.env_remove(var);
+    }
+
+    for (key, value) in set {
+        tracing::info!(key, "setting environment variable");
+        cmd.env(key, value);
+    }
+
+    if set_git_optional_locks {
+        cmd.env("GIT_OPTIONAL_LOCKS", "0");
     }
 }
 
@@ -190,10 +174,10 @@ fn read_only_command(command: &str, has_bash: bool) -> Result<PreparedCommand, S
             |e| Status::internal(format!("Failed to set read-only script permissions: {e:?}")),
         )?;
 
-        if has_bash && is_bash_shebang(first_line) {
+        if has_bash && shell_script::is_bash_shebang(first_line) {
             let mut cmd = tokio::process::Command::new("/bin/bash");
             cmd.arg("--login");
-            if let Some(args) = shebang_args(first_line) {
+            if let Some(args) = shell_script::bash_args(first_line) {
                 cmd.args(args);
             }
             cmd.arg(script_path);
@@ -203,7 +187,7 @@ fn read_only_command(command: &str, has_bash: bool) -> Result<PreparedCommand, S
             });
         }
 
-        let (interpreter, args) = shebang_command(first_line)
+        let (interpreter, args) = shell_script::command(first_line)
             .ok_or_else(|| Status::internal(format!("Failed to parse shebang: {first_line}")))?;
         let mut cmd = tokio::process::Command::new(interpreter);
         cmd.args(args);
@@ -224,46 +208,4 @@ fn read_only_command(command: &str, has_bash: bool) -> Result<PreparedCommand, S
         command: cmd,
         script_dir: None,
     })
-}
-
-#[cfg(target_os = "linux")]
-fn is_bash_shebang(line: &str) -> bool {
-    let Some(command) = line.strip_prefix("#!") else {
-        return false;
-    };
-
-    let mut parts = command.split_whitespace();
-    match (parts.next(), parts.next()) {
-        (Some(interpreter), _) if interpreter.ends_with("/bash") || interpreter == "bash" => true,
-        (Some(interpreter), Some(program))
-            if interpreter.ends_with("/env")
-                && (program == "bash" || program.ends_with("/bash")) =>
-        {
-            true
-        }
-        _ => false,
-    }
-}
-
-#[cfg(target_os = "linux")]
-fn shebang_command(line: &str) -> Option<(&str, Vec<&str>)> {
-    let command = line.strip_prefix("#!")?;
-    let mut parts = command.split_whitespace();
-    let interpreter = parts.next()?;
-
-    Some((interpreter, parts.collect()))
-}
-
-#[cfg(target_os = "linux")]
-fn shebang_args(line: &str) -> Option<Vec<&str>> {
-    let (interpreter, mut parts) = shebang_command(line)?;
-
-    if interpreter.ends_with("/env") {
-        if parts.is_empty() {
-            return None;
-        }
-        parts.remove(0);
-    }
-
-    Some(parts)
 }

--- a/swiftide-docker-service/src/read_only_shell.rs
+++ b/swiftide-docker-service/src/read_only_shell.rs
@@ -209,16 +209,3 @@ fn read_only_command(command: &str, has_bash: bool) -> Result<PreparedCommand, S
         script_dir: None,
     })
 }
-
-#[cfg(all(test, target_os = "linux"))]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn read_only_command_keeps_shebang_script_alive() {
-        let prepared = read_only_command("#!/bin/bash\nprintf ok", true)
-            .expect("shebang command should build");
-
-        assert!(prepared.script_dir.is_some());
-    }
-}

--- a/swiftide-docker-service/src/read_only_shell.rs
+++ b/swiftide-docker-service/src/read_only_shell.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path};
 use tokio::process::Child;
 use tonic::Status;
 
-use crate::command_cleanup::{CommandCleanup, ProcessGroup};
+use crate::command_cleanup::CommandCleanup;
 #[cfg(target_os = "linux")]
 use crate::read_only_sandbox;
 
@@ -50,9 +50,8 @@ impl CommandEnv {
 
 pub(crate) struct SpawnedReadOnlyCommand {
     child: Child,
-    process_group: Option<ProcessGroup>,
     #[cfg(target_os = "linux")]
-    _scratch: ScratchDir,
+    _script_dir: Option<ScriptDir>,
 }
 
 impl SpawnedReadOnlyCommand {
@@ -62,12 +61,6 @@ impl SpawnedReadOnlyCommand {
 
     pub(crate) fn terminate(self) {
         CommandCleanup::new(self.child).terminate();
-    }
-
-    pub(crate) fn cleanup_process_group(&self) {
-        if let Some(process_group) = self.process_group {
-            process_group.kill_or_log("completed read-only command");
-        }
     }
 }
 
@@ -87,52 +80,56 @@ pub(crate) fn spawn(
 
     #[cfg(target_os = "linux")]
     {
-        let scratch = ScratchDir::new()?;
         let has_bash = Path::new("/bin/bash").exists();
-        let mut cmd = read_only_command(command, scratch.path(), has_bash)?;
+        let prepared = read_only_command(command, has_bash)?;
+        let mut cmd = prepared.command;
 
-        env.apply(&mut cmd, scratch.path());
+        env.apply(&mut cmd);
         cmd.current_dir(workdir.path())
             .process_group(0)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped());
 
-        read_only_sandbox::apply_to_command(&mut cmd, scratch.path())
+        read_only_sandbox::apply_to_command(&mut cmd)
             .map_err(|e| Status::internal(format!("Failed to apply read-only sandbox: {e:?}")))?;
 
         let child = cmd.spawn().map_err(|e| {
             tracing::error!(error = ?e, "Failed to start read-only command");
             Status::internal(format!("Failed to start read-only command: {e:?}"))
         })?;
-        let process_group = ProcessGroup::from_child(&child);
 
         Ok(SpawnedReadOnlyCommand {
             child,
-            process_group,
-            _scratch: scratch,
+            _script_dir: prepared.script_dir,
         })
     }
 }
 
 #[cfg(target_os = "linux")]
-struct ScratchDir {
+struct PreparedCommand {
+    command: tokio::process::Command,
+    script_dir: Option<ScriptDir>,
+}
+
+#[cfg(target_os = "linux")]
+struct ScriptDir {
     inner: tempfile::TempDir,
 }
 
 #[cfg(target_os = "linux")]
-impl ScratchDir {
+impl ScriptDir {
     fn new() -> Result<Self, Status> {
         use std::os::unix::fs::PermissionsExt as _;
 
         let inner = tempfile::Builder::new()
-            .prefix("swiftide-readonly-")
+            .prefix("swiftide-readonly-script-")
             .tempdir_in("/tmp")
             .map_err(|e| {
-                Status::internal(format!("Failed to create read-only scratch dir: {e:?}"))
+                Status::internal(format!("Failed to create read-only script dir: {e:?}"))
             })?;
         std::fs::set_permissions(inner.path(), std::fs::Permissions::from_mode(0o700)).map_err(
-            |e| Status::internal(format!("Failed to protect read-only scratch dir: {e:?}")),
+            |e| Status::internal(format!("Failed to protect read-only script dir: {e:?}")),
         )?;
 
         Ok(Self { inner })
@@ -145,7 +142,7 @@ impl ScratchDir {
 
 #[cfg(target_os = "linux")]
 impl CommandEnv {
-    fn apply(&self, cmd: &mut tokio::process::Command, scratch: &Path) {
+    fn apply(&self, cmd: &mut tokio::process::Command) {
         if self.clear {
             tracing::info!("clearing environment variables");
             cmd.env_clear();
@@ -161,10 +158,6 @@ impl CommandEnv {
             cmd.env(key, value);
         }
 
-        if self.should_set_default("TMPDIR") {
-            cmd.env("TMPDIR", scratch);
-        }
-
         if self.should_set_default("GIT_OPTIONAL_LOCKS") {
             cmd.env("GIT_OPTIONAL_LOCKS", "0");
         }
@@ -176,11 +169,7 @@ impl CommandEnv {
 }
 
 #[cfg(target_os = "linux")]
-fn read_only_command(
-    command: &str,
-    scratch: &Path,
-    has_bash: bool,
-) -> Result<tokio::process::Command, Status> {
+fn read_only_command(command: &str, has_bash: bool) -> Result<PreparedCommand, Status> {
     use std::{io::Write as _, os::unix::fs::PermissionsExt as _};
 
     let lines = command.lines().collect::<Vec<_>>();
@@ -188,7 +177,8 @@ fn read_only_command(
     if let Some(first_line) = lines.first()
         && first_line.starts_with("#!")
     {
-        let script_path = scratch.join("script");
+        let script_dir = ScriptDir::new()?;
+        let script_path = script_dir.path().join("script");
         let mut script = std::fs::File::create(&script_path)
             .map_err(|e| Status::internal(format!("Failed to create read-only script: {e:?}")))?;
         script
@@ -207,7 +197,10 @@ fn read_only_command(
                 cmd.args(args);
             }
             cmd.arg(script_path);
-            return Ok(cmd);
+            return Ok(PreparedCommand {
+                command: cmd,
+                script_dir: Some(script_dir),
+            });
         }
 
         let (interpreter, args) = shebang_command(first_line)
@@ -215,7 +208,10 @@ fn read_only_command(
         let mut cmd = tokio::process::Command::new(interpreter);
         cmd.args(args);
         cmd.arg(script_path);
-        return Ok(cmd);
+        return Ok(PreparedCommand {
+            command: cmd,
+            script_dir: Some(script_dir),
+        });
     }
 
     let shell = if has_bash { "/bin/bash" } else { "sh" };
@@ -224,7 +220,10 @@ fn read_only_command(
         cmd.arg("--login");
     }
     cmd.arg("-c").arg(command);
-    Ok(cmd)
+    Ok(PreparedCommand {
+        command: cmd,
+        script_dir: None,
+    })
 }
 
 #[cfg(target_os = "linux")]

--- a/swiftide-docker-service/src/read_only_shell.rs
+++ b/swiftide-docker-service/src/read_only_shell.rs
@@ -209,3 +209,16 @@ fn read_only_command(command: &str, has_bash: bool) -> Result<PreparedCommand, S
         script_dir: None,
     })
 }
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_only_command_keeps_shebang_script_alive() {
+        let prepared = read_only_command("#!/bin/bash\nprintf ok", true)
+            .expect("shebang command should build");
+
+        assert!(prepared.script_dir.is_some());
+    }
+}

--- a/swiftide-docker-service/src/read_only_shell.rs
+++ b/swiftide-docker-service/src/read_only_shell.rs
@@ -1,0 +1,270 @@
+use std::{collections::HashMap, path::Path};
+
+use tokio::process::Child;
+use tonic::Status;
+
+use crate::command_cleanup::{CommandCleanup, ProcessGroup};
+#[cfg(target_os = "linux")]
+use crate::read_only_sandbox;
+
+pub(crate) struct ReadOnlyWorkdir {
+    path: std::path::PathBuf,
+}
+
+impl ReadOnlyWorkdir {
+    pub(crate) fn try_new(path: impl Into<std::path::PathBuf>) -> Result<Self, Status> {
+        let path = path.into();
+        let metadata = std::fs::metadata(&path).map_err(|e| {
+            Status::failed_precondition(format!(
+                "read-only shell workdir does not exist: {}: {e}",
+                path.display()
+            ))
+        })?;
+
+        if !metadata.is_dir() {
+            return Err(Status::failed_precondition(format!(
+                "read-only shell workdir is not a directory: {}",
+                path.display()
+            )));
+        }
+
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+pub(crate) struct CommandEnv {
+    clear: bool,
+    remove: Vec<String>,
+    set: HashMap<String, String>,
+}
+
+impl CommandEnv {
+    pub(crate) fn new(clear: bool, remove: Vec<String>, set: HashMap<String, String>) -> Self {
+        Self { clear, remove, set }
+    }
+}
+
+pub(crate) struct SpawnedReadOnlyCommand {
+    child: Child,
+    process_group: Option<ProcessGroup>,
+    #[cfg(target_os = "linux")]
+    _scratch: ScratchDir,
+}
+
+impl SpawnedReadOnlyCommand {
+    pub(crate) fn child_mut(&mut self) -> &mut Child {
+        &mut self.child
+    }
+
+    pub(crate) fn terminate(self) {
+        CommandCleanup::new(self.child).terminate();
+    }
+
+    pub(crate) fn cleanup_process_group(&self) {
+        if let Some(process_group) = self.process_group {
+            process_group.kill_or_log("completed read-only command");
+        }
+    }
+}
+
+pub(crate) fn spawn(
+    command: &str,
+    workdir: ReadOnlyWorkdir,
+    env: CommandEnv,
+) -> Result<SpawnedReadOnlyCommand, Status> {
+    #[cfg(not(target_os = "linux"))]
+    {
+        let CommandEnv { clear, remove, set } = env;
+        let _ = (command, workdir.path(), clear, remove, set);
+        Err(Status::unimplemented(
+            "read-only shell is only supported on Linux",
+        ))
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let scratch = ScratchDir::new()?;
+        let has_bash = Path::new("/bin/bash").exists();
+        let mut cmd = read_only_command(command, scratch.path(), has_bash)?;
+
+        env.apply(&mut cmd, scratch.path());
+        cmd.current_dir(workdir.path())
+            .process_group(0)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped());
+
+        read_only_sandbox::apply_to_command(&mut cmd, scratch.path())
+            .map_err(|e| Status::internal(format!("Failed to apply read-only sandbox: {e:?}")))?;
+
+        let child = cmd.spawn().map_err(|e| {
+            tracing::error!(error = ?e, "Failed to start read-only command");
+            Status::internal(format!("Failed to start read-only command: {e:?}"))
+        })?;
+        let process_group = ProcessGroup::from_child(&child);
+
+        Ok(SpawnedReadOnlyCommand {
+            child,
+            process_group,
+            _scratch: scratch,
+        })
+    }
+}
+
+#[cfg(target_os = "linux")]
+struct ScratchDir {
+    inner: tempfile::TempDir,
+}
+
+#[cfg(target_os = "linux")]
+impl ScratchDir {
+    fn new() -> Result<Self, Status> {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let inner = tempfile::Builder::new()
+            .prefix("swiftide-readonly-")
+            .tempdir_in("/tmp")
+            .map_err(|e| {
+                Status::internal(format!("Failed to create read-only scratch dir: {e:?}"))
+            })?;
+        std::fs::set_permissions(inner.path(), std::fs::Permissions::from_mode(0o700)).map_err(
+            |e| Status::internal(format!("Failed to protect read-only scratch dir: {e:?}")),
+        )?;
+
+        Ok(Self { inner })
+    }
+
+    fn path(&self) -> &Path {
+        self.inner.path()
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl CommandEnv {
+    fn apply(&self, cmd: &mut tokio::process::Command, scratch: &Path) {
+        if self.clear {
+            tracing::info!("clearing environment variables");
+            cmd.env_clear();
+        }
+
+        for var in &self.remove {
+            tracing::info!(var, "clearing environment variable");
+            cmd.env_remove(var);
+        }
+
+        for (key, value) in &self.set {
+            tracing::info!(key, "setting environment variable");
+            cmd.env(key, value);
+        }
+
+        if self.should_set_default("TMPDIR") {
+            cmd.env("TMPDIR", scratch);
+        }
+
+        if self.should_set_default("GIT_OPTIONAL_LOCKS") {
+            cmd.env("GIT_OPTIONAL_LOCKS", "0");
+        }
+    }
+
+    fn should_set_default(&self, key: &str) -> bool {
+        !self.set.contains_key(key) && !self.remove.iter().any(|var| var == key)
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn read_only_command(
+    command: &str,
+    scratch: &Path,
+    has_bash: bool,
+) -> Result<tokio::process::Command, Status> {
+    use std::{io::Write as _, os::unix::fs::PermissionsExt as _};
+
+    let lines = command.lines().collect::<Vec<_>>();
+
+    if let Some(first_line) = lines.first()
+        && first_line.starts_with("#!")
+    {
+        let script_path = scratch.join("script");
+        let mut script = std::fs::File::create(&script_path)
+            .map_err(|e| Status::internal(format!("Failed to create read-only script: {e:?}")))?;
+        script
+            .write_all(command.as_bytes())
+            .map_err(|e| Status::internal(format!("Failed to write read-only script: {e:?}")))?;
+        drop(script);
+
+        std::fs::set_permissions(&script_path, std::fs::Permissions::from_mode(0o755)).map_err(
+            |e| Status::internal(format!("Failed to set read-only script permissions: {e:?}")),
+        )?;
+
+        if has_bash && is_bash_shebang(first_line) {
+            let mut cmd = tokio::process::Command::new("/bin/bash");
+            cmd.arg("--login");
+            if let Some(args) = shebang_args(first_line) {
+                cmd.args(args);
+            }
+            cmd.arg(script_path);
+            return Ok(cmd);
+        }
+
+        let (interpreter, args) = shebang_command(first_line)
+            .ok_or_else(|| Status::internal(format!("Failed to parse shebang: {first_line}")))?;
+        let mut cmd = tokio::process::Command::new(interpreter);
+        cmd.args(args);
+        cmd.arg(script_path);
+        return Ok(cmd);
+    }
+
+    let shell = if has_bash { "/bin/bash" } else { "sh" };
+    let mut cmd = tokio::process::Command::new(shell);
+    if has_bash {
+        cmd.arg("--login");
+    }
+    cmd.arg("-c").arg(command);
+    Ok(cmd)
+}
+
+#[cfg(target_os = "linux")]
+fn is_bash_shebang(line: &str) -> bool {
+    let Some(command) = line.strip_prefix("#!") else {
+        return false;
+    };
+
+    let mut parts = command.split_whitespace();
+    match (parts.next(), parts.next()) {
+        (Some(interpreter), _) if interpreter.ends_with("/bash") || interpreter == "bash" => true,
+        (Some(interpreter), Some(program))
+            if interpreter.ends_with("/env")
+                && (program == "bash" || program.ends_with("/bash")) =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn shebang_command(line: &str) -> Option<(&str, Vec<&str>)> {
+    let command = line.strip_prefix("#!")?;
+    let mut parts = command.split_whitespace();
+    let interpreter = parts.next()?;
+
+    Some((interpreter, parts.collect()))
+}
+
+#[cfg(target_os = "linux")]
+fn shebang_args(line: &str) -> Option<Vec<&str>> {
+    let (interpreter, mut parts) = shebang_command(line)?;
+
+    if interpreter.ends_with("/env") {
+        if parts.is_empty() {
+            return None;
+        }
+        parts.remove(0);
+    }
+
+    Some(parts)
+}

--- a/swiftide-docker-service/src/shell_script.rs
+++ b/swiftide-docker-service/src/shell_script.rs
@@ -1,0 +1,38 @@
+pub(crate) fn is_bash_shebang(line: &str) -> bool {
+    let Some(command) = line.strip_prefix("#!") else {
+        return false;
+    };
+
+    let mut parts = command.split_whitespace();
+    match (parts.next(), parts.next()) {
+        (Some(interpreter), _) if interpreter.ends_with("/bash") || interpreter == "bash" => true,
+        (Some(interpreter), Some(program))
+            if interpreter.ends_with("/env")
+                && (program == "bash" || program.ends_with("/bash")) =>
+        {
+            true
+        }
+        _ => false,
+    }
+}
+
+pub(crate) fn command(line: &str) -> Option<(&str, Vec<&str>)> {
+    let command = line.strip_prefix("#!")?;
+    let mut parts = command.split_whitespace();
+    let interpreter = parts.next()?;
+
+    Some((interpreter, parts.collect()))
+}
+
+pub(crate) fn bash_args(line: &str) -> Option<Vec<&str>> {
+    let (interpreter, mut parts) = command(line)?;
+
+    if interpreter.ends_with("/env") {
+        if parts.is_empty() {
+            return None;
+        }
+        parts.remove(0);
+    }
+
+    Some(parts)
+}


### PR DESCRIPTION
## Summary

- Add a separate `ExecReadOnlyShell` gRPC method and route Swiftide `Command::ReadOnlyShell` through it.
- Keep the Linux read-only sandbox plumbing isolated in `read_only_sandbox.rs`.
- Enforce read-only shell execution on Linux with Landlock denying write-like filesystem rights and a small seccomp filter denying chmod/chown/timestamp metadata mutation.
- Preserve the configured executor environment over gRPC, including `HOME`, and default `GIT_OPTIONAL_LOCKS=0` for common read-only git commands.
- Fail closed for unsupported platforms/services instead of falling back to unrestricted shell execution.
- Use the Swiftide `feat/read-only-shell-command` branch through the workspace patch while Swiftide support is unreleased.
- Add high-level DockerExecutor tests for reading the workdir, blocking writes inside and outside the workdir, blocking temp-path writes and metadata mutation, preserving env/HOME, and shebang/login-shell behavior.
- Add focused Linux unit tests for the generated Landlock/seccomp sandbox policy without applying seccomp to the test process.
- Document the read-only shell behavior and the local high-level test command.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo clippy -p swiftide-docker-service --all-targets --target x86_64-unknown-linux-gnu --locked -- -D warnings`
- `cargo test -p swiftide-docker-service read_only --locked`
- `just test -p swiftide-docker-executor read_only`
- GitHub CI for PR #138: Lint, Test, Test Buildkit, and Coverage all passed.